### PR TITLE
Implement markdown heading anchor links

### DIFF
--- a/packages/gatsby-theme-primer/package.json
+++ b/packages/gatsby-theme-primer/package.json
@@ -30,6 +30,7 @@
     "prism-react-renderer": "^0.1.7",
     "react-live": "^2.1.2",
     "sentence-case": "^2.1.1",
+    "slugify": "^1.3.4",
     "styled-components": "^4.3.2"
   }
 }

--- a/packages/gatsby-theme-primer/src/components/heading.js
+++ b/packages/gatsby-theme-primer/src/components/heading.js
@@ -1,37 +1,72 @@
-import {Heading} from '@primer/components'
+import {Heading, Link, StyledOcticon} from '@primer/components'
+import {Link as LinkIcon} from '@primer/octicons-react'
 import themeGet from '@styled-system/theme-get'
+import React from 'react'
+import slugify from 'slugify'
 import styled from 'styled-components'
 
 const StyledHeading = styled(Heading)`
   margin-top: ${themeGet('space.4')}px;
   margin-bottom: ${themeGet('space.3')}px;
+
+  & .octicon-link {
+    visibility: hidden;
+  }
+
+  &:hover .octicon-link,
+  &:focus-within .octicon-link {
+    visibility: visible;
+  }
 `
 
-export const H1 = styled(StyledHeading).attrs({as: 'h1'})`
+function MarkdownHeading({children, ...props}) {
+  const id = children ? slugify(children.toString(), {lower: true}) : ''
+  return (
+    <StyledHeading id={id} {...props}>
+      <Link href={`#${id}`} p={2} ml={-32} color="gray.8">
+        <StyledOcticon
+          className="octicon-link"
+          icon={LinkIcon}
+          verticalAlign="middle"
+        />
+      </Link>
+      {children}
+    </StyledHeading>
+  )
+}
+
+const StyledH1 = styled(StyledHeading).attrs({as: 'h1'})`
   padding-bottom: ${themeGet('space.1')}px;
   font-size: ${themeGet('fontSizes.5')}px;
   border-bottom: 1px solid ${themeGet('colors.gray.2')};
 `
 
-export const H2 = styled(StyledHeading).attrs({as: 'h2'})`
+const StyledH2 = styled(StyledHeading).attrs({as: 'h2'})`
   padding-bottom: ${themeGet('space.1')}px;
   font-size: ${themeGet('fontSizes.4')}px;
   border-bottom: 1px solid ${themeGet('colors.gray.2')};
 `
 
-export const H3 = styled(StyledHeading).attrs({as: 'h3'})`
+const StyledH3 = styled(StyledHeading).attrs({as: 'h3'})`
   font-size: ${themeGet('fontSizes.3')}px;
 `
 
-export const H4 = styled(StyledHeading).attrs({as: 'h4'})`
+const StyledH4 = styled(StyledHeading).attrs({as: 'h4'})`
   font-size: ${themeGet('fontSizes.2')}px;
 `
 
-export const H5 = styled(StyledHeading).attrs({as: 'h5'})`
+const StyledH5 = styled(StyledHeading).attrs({as: 'h5'})`
   font-size: ${themeGet('fontSizes.1')}px;
 `
 
-export const H6 = styled(StyledHeading).attrs({as: 'h6'})`
+const StyledH6 = styled(StyledHeading).attrs({as: 'h6'})`
   font-size: ${themeGet('fontSizes.1')}px;
   color: ${themeGet('colors.gray.5')};
 `
+
+export const H1 = props => <MarkdownHeading as={StyledH1} {...props} />
+export const H2 = props => <MarkdownHeading as={StyledH2} {...props} />
+export const H3 = props => <MarkdownHeading as={StyledH3} {...props} />
+export const H4 = props => <MarkdownHeading as={StyledH4} {...props} />
+export const H5 = props => <MarkdownHeading as={StyledH5} {...props} />
+export const H6 = props => <MarkdownHeading as={StyledH6} {...props} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9861,6 +9861,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+slugify@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.4.tgz#78d2792d7222b55cd9fc81fa018df99af779efeb"
+  integrity sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw==
+
 snake-case@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"


### PR DESCRIPTION
Implements markdown heading links similar to the ones on dotcom:

![Kapture 2019-07-11 at 9 11 04](https://user-images.githubusercontent.com/4608155/61067210-e6ecc800-a3bb-11e9-99dd-0aa916a95e74.gif)
