### PR TITLE
Update deployment guide with new routes format

### DIFF
--- a/docs/src/pages/guides/deployment.mdx
+++ b/docs/src/pages/guides/deployment.mdx
@@ -64,7 +64,7 @@ After your `pathPrefix` is set up, open a pull request on the [primer/primer.sty
     {"src": "/css(/.*)?", "dest": "https://primer-css.now.sh"},
     {"src": "/design(/.*)?", "dest": "https://primer-design.now.sh"},
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
-+   {"src": "/my-site(/.*)?", "dest": "https://primer-my-site.now.sh"},
++   {"src": "/my-site(/.*)?", "dest": "https://my-site.now.sh"},
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"}
   ]}
 ```


### PR DESCRIPTION
This changed in primer/primer.style#157 with the migration to Now v2.