### PR TITLE
Fix details component in Edge

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -16,10 +16,11 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.0.21",
     "@mdx-js/react": "^1.0.21",
-    "@primer/components": "^13.2.0",
+    "@primer/components": "^13.3.1",
     "@primer/octicons-react": "^9.1.1",
     "@styled-system/theme-get": "^5.0.12",
     "copy-to-clipboard": "^3.2.0",
+    "details-element-polyfill": "^2.4.0",
     "downshift": "^3.2.10",
     "find-up": "^4.1.0",
     "framer-motion": "^1.4.2",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {

--- a/theme/src/components/details.js
+++ b/theme/src/components/details.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import styled from 'styled-components'
+
+// The <details> element is not yet supported in Edge so we have to use a polyfill.
+if (typeof window !== 'undefined') {
+  import('details-element-polyfill')
+}
+
+// TODO: Replace this Details component with the one from @primer/components when 14.0.0 is released.
+// Reference: https://github.com/primer/components/pull/49
+
+const DetailsReset = styled.details`
+  & > summary {
+    list-style: none;
+  }
+
+  & > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  & > summary::before {
+    display: none;
+  }
+`
+function getRenderer(children) {
+  return typeof children === 'function' ? children : () => children
+}
+
+function Details({children, overlay, render = getRenderer(children), ...rest}) {
+  const [open, setOpen] = React.useState(Boolean(rest.open))
+
+  function toggle(event) {
+    if (event) event.preventDefault()
+    if (overlay) {
+      openMenu()
+    } else {
+      setOpen(!open)
+    }
+  }
+
+  function openMenu() {
+    if (!open) {
+      setOpen(true)
+      document.addEventListener('click', closeMenu)
+    }
+  }
+
+  function closeMenu() {
+    setOpen(false)
+    document.removeEventListener('click', closeMenu)
+  }
+
+  return (
+    <DetailsReset {...rest} open={open}>
+      {render({open, toggle})}
+    </DetailsReset>
+  )
+}
+
+Details.defaultProps = {
+  overlay: false,
+}
+
+export default Details

--- a/theme/src/components/details.js
+++ b/theme/src/components/details.js
@@ -2,12 +2,14 @@ import React from 'react'
 import styled from 'styled-components'
 
 // The <details> element is not yet supported in Edge so we have to use a polyfill.
+// We have to check if window is defined before importing the polyfill
+// so the code doesn’t run while Gatsby is building.
 if (typeof window !== 'undefined') {
   import('details-element-polyfill')
 }
 
 // TODO: Replace this Details component with the one from @primer/components when 14.0.0 is released.
-// Reference: https://github.com/primer/components/pull/49
+// Reference: https://github.com/primer/components/pull/499
 
 const DetailsReset = styled.details`
   & > summary {
@@ -22,6 +24,7 @@ const DetailsReset = styled.details`
     display: none;
   }
 `
+
 function getRenderer(children) {
   return typeof children === 'function' ? children : () => children
 }

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -1,7 +1,6 @@
 import {
   BorderBox,
   Box,
-  Details,
   Flex,
   Link,
   StyledOcticon,
@@ -14,6 +13,7 @@ import navItems from '../nav.yml'
 import primerNavItems from '../primer-nav.yml'
 import useSiteMetadata from '../use-site-metadata'
 import DarkButton from './dark-button'
+import Details from './details'
 import Drawer from './drawer'
 import NavItems from './nav-items'
 

--- a/theme/src/components/nav-dropdown.js
+++ b/theme/src/components/nav-dropdown.js
@@ -8,50 +8,30 @@ import {
 import {ChevronDown} from '@primer/octicons-react'
 import React from 'react'
 import styled from 'styled-components'
-
-// TODO: Replace this Details component with the one from @primer/components when 14.0.0 is released.
-// Reference: https://github.com/primer/components/pull/499
-const Details = styled.details`
-  & > summary {
-    list-style: none;
-  }
-
-  & > summary::-webkit-details-marker {
-    display: none;
-  }
-`
+import Details from './details'
 
 function NavDropdown({title, children}) {
-  const [open, setOpen] = React.useState(false)
-
-  React.useEffect(() => {
-    if (open) {
-      document.addEventListener('click', closeMenu)
-      return () => {
-        document.removeEventListener('click', closeMenu)
-      }
-    }
-  }, [open])
-
-  function toggle(event) {
-    setOpen(event.target.open)
-  }
-
-  function closeMenu() {
-    setOpen(false)
-  }
-
   return (
-    <Details open={open} onToggle={toggle}>
-      <summary style={{cursor: 'pointer'}}>
-        <Text>{title}</Text>
-        <StyledOcticon icon={ChevronDown} ml={1} />
-      </summary>
-      <Absolute>
-        <BorderBox bg="white" py={1} mt={2} boxShadow="medium" color="gray.8">
-          {children}
-        </BorderBox>
-      </Absolute>
+    <Details overlay={true}>
+      {({toggle}) => (
+        <>
+          <summary style={{cursor: 'pointer'}} onClick={toggle}>
+            <Text>{title}</Text>
+            <StyledOcticon icon={ChevronDown} ml={1} />
+          </summary>
+          <Absolute>
+            <BorderBox
+              bg="white"
+              py={1}
+              mt={2}
+              boxShadow="medium"
+              color="gray.8"
+            >
+              {children}
+            </BorderBox>
+          </Absolute>
+        </>
+      )}
     </Details>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@
     hey-listen "^1.0.8"
     style-value-types "^3.1.6"
 
-"@primer/components@^13.2.0":
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/@primer/components/-/components-13.3.0.tgz#79183735b4a52feca9ccb4e1aef93605160ceac2"
-  integrity sha512-Vikz8a1vv0+h5x8shwpqehEwtoKtROEMvwtvl54kePN0mo/vd/sheO9esdwRVZ1IafLncP2GVyRV1qZSdC+jPQ==
+"@primer/components@^13.3.1":
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/@primer/components/-/components-13.3.1.tgz#1b68596b914c2c42ba0153c762ee28a280dcc4b3"
+  integrity sha512-WOT7sbrbaPl+PODIzArHPfs0jiJVfvZsMj+Ea4gStSF//h1EVkT4JiDqpOqrZr7ihwaAa32Evtsbw0KGNHG5pg==
   dependencies:
     "@primer/octicons-react" "9.0.0"
     "@reach/dialog" "0.2.9"
@@ -3636,6 +3636,11 @@ detab@2.0.2, detab@^2.0.0:
   integrity sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==
   dependencies:
     repeat-string "^1.5.4"
+
+details-element-polyfill@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz#e0622adef7902662faf27b4ab8acba5dc4e3a6e6"
+  integrity sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g==
 
 detect-indent@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
# Problem

All the dropdowns are stuck open in Edge because Edge doesn't support the `<details>` element 😢 

![image](https://user-images.githubusercontent.com/4608155/63283070-174e3e80-c265-11e9-9b0a-7ff188368693.png)


# Solution

Use [`details-element-polyfill`](https://www.npmjs.com/package/details-element-polyfill) to polyfill the `<details>` element for Edge. 

For now, I copied the [`Details`](https://github.com/primer/blueprints/blob/master/src/Details.js) component from Blueprints. When the `Details` component is updated  in`@primer/components`  `v14.0.0`, we should switch to using that.