### PR TITLE
Fix nav drawer

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -20,7 +20,7 @@ function NavDrawer({isOpen, onDismiss}) {
         bg="gray.9"
         style={{overflow: 'auto', WebkitOverflowScrolling: 'touch'}}
       >
-        <Flex flexDirection="column" color="blue.2" bg="gray.9">
+        <Flex flexDirection="column" flex="1 0 auto" color="blue.2" bg="gray.9">
           <BorderBox
             border={0}
             borderRadius={0}
@@ -53,7 +53,7 @@ function NavDrawer({isOpen, onDismiss}) {
         {navItems.length > 0 ? (
           <Flex
             flexDirection="column"
-            flex="1 1 auto"
+            flex="1 0 auto"
             color="gray.7"
             bg="gray.0"
           >


### PR DESCRIPTION
I recently added a flex container inside the navigation drawer which broke its layout on mobile. This pull request fixes that issue by using the `flex` property to ensure nothing shrinks unexpectedly. 


<details>
<summary><strong>Before</strong></summary>

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/4608155/64067348-12ca4400-cbdc-11e9-9093-f1f63a7f893e.gif)

</details>

<details>
<summary><strong>After</strong></summary>

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/4608155/64067302-67b98a80-cbdb-11e9-8b4c-035c3e073a33.gif)

</details>
