### PR TITLE
Add GitHub link to the sidebar

### DIFF
--- a/docs/content/usage/customization.mdx
+++ b/docs/content/usage/customization.mdx
@@ -42,14 +42,20 @@ Side navigation for your site is generated from the content in `src/@primer/gats
 
 _Note: Doctocat only supports one level of nesting._
 
-## Edit on GitHub link
+## Repository
 
-To add an "Edit this page on GitHub" link to the bottom of every page, you'll need to specify your site's [`repository`](https://docs.npmjs.com/files/package.json#repository) in `package.json`:
+Doctocat has a few features that rely on information about your repository, including:
+
+- "Edit this page on GitHub" links on the bottom of every page
+- Contributors on the bottom of every page
+- Repository link in the sidebar
+
+To enable these features, you'll need to specify your site's [`repository`](https://docs.npmjs.com/files/package.json#repository) in `package.json`:
 
 ```json
 // package.json
 {
-  "repository": "my-username/my-site"
+  "repository": "repo-owner/repo-name"
 }
 ```
 

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -4,8 +4,27 @@ const getPkgRepo = require('get-pkg-repo')
 const axios = require('axios')
 const uniqBy = require('lodash.uniqby')
 
+exports.sourceNodes = async ({actions, createContentDigest}) => {
+  // Make the repository URL accessible through Gatsby's GraphQL API.
+  const repo = getRepo()
+  const url = `https://github.com/${repo.user}/${repo.project}`
+  const node = {
+    url,
+    id: `repository`,
+    parent: null,
+    children: [],
+    internal: {
+      type: 'Repository',
+      mediaType: 'application/json',
+      content: JSON.stringify({url}),
+      contentDigest: createContentDigest({url}),
+    },
+  }
+  actions.createNode(node)
+}
+
 exports.createPages = async ({graphql, actions}, themeOptions) => {
-  const repo = getPkgRepo(readPkgUp.sync().package)
+  const repo = getRepo()
 
   const {data} = await graphql(`
     {
@@ -60,6 +79,10 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
       })
     }),
   )
+}
+
+function getRepo() {
+  return getPkgRepo(readPkgUp.sync().package)
 }
 
 function getEditUrl(repo, filePath) {

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -4,7 +4,7 @@ const getPkgRepo = require('get-pkg-repo')
 const axios = require('axios')
 const uniqBy = require('lodash.uniqby')
 
-exports.sourceNodes = async ({actions, createContentDigest}) => {
+exports.sourceNodes = ({actions, createContentDigest}) => {
   // Make the repository URL accessible through Gatsby's GraphQL API.
   const repo = getRepo()
   const url = `https://github.com/${repo.user}/${repo.project}`

--- a/theme/src/components/nav-items.js
+++ b/theme/src/components/nav-items.js
@@ -1,5 +1,12 @@
-import {BorderBox, Flex, Link, themeGet} from '@primer/components'
-import {Link as GatsbyLink} from 'gatsby'
+import {
+  BorderBox,
+  Flex,
+  Link,
+  StyledOcticon,
+  themeGet,
+} from '@primer/components'
+import {LinkExternal} from '@primer/octicons-react'
+import {graphql, Link as GatsbyLink, useStaticQuery} from 'gatsby'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -11,39 +18,71 @@ const NavLink = styled(Link)`
 `
 
 function NavItems({items}) {
-  return items.map(item => (
-    <BorderBox key={item.title} border={0} borderRadius={0} borderTop={1} p={4}>
-      <Flex flexDirection="column">
-        <NavLink
-          as={GatsbyLink}
-          to={item.url}
-          activeClassName="active"
-          partiallyActive={true}
-          color="inherit"
+  return (
+    <>
+      {items.map(item => (
+        <BorderBox
+          key={item.title}
+          border={0}
+          borderRadius={0}
+          borderTop={1}
+          p={4}
         >
-          {item.title}
-        </NavLink>
-        {item.children ? (
-          <Flex flexDirection="column" mt={2}>
-            {item.children.map(child => (
-              <NavLink
-                key={child.title}
-                as={GatsbyLink}
-                to={child.url}
-                activeClassName="active"
-                display="block"
-                py={1}
-                mt={2}
-                fontSize={1}
-              >
-                {child.title}
-              </NavLink>
-            ))}
+          <Flex flexDirection="column">
+            <NavLink
+              as={GatsbyLink}
+              to={item.url}
+              activeClassName="active"
+              partiallyActive={true}
+              color="inherit"
+            >
+              {item.title}
+            </NavLink>
+            {item.children ? (
+              <Flex flexDirection="column" mt={2}>
+                {item.children.map(child => (
+                  <NavLink
+                    key={child.title}
+                    as={GatsbyLink}
+                    to={child.url}
+                    activeClassName="active"
+                    display="block"
+                    py={1}
+                    mt={2}
+                    fontSize={1}
+                  >
+                    {child.title}
+                  </NavLink>
+                ))}
+              </Flex>
+            ) : null}
           </Flex>
-        ) : null}
+        </BorderBox>
+      ))}
+      <BorderBox border={0} borderRadius={0} borderTop={1} p={4}>
+        <GithubLink />
+      </BorderBox>
+    </>
+  )
+}
+
+function GithubLink() {
+  const data = useStaticQuery(graphql`
+    {
+      repository {
+        url
+      }
+    }
+  `)
+
+  return (
+    <Link href={data.repository.url} color="inherit">
+      <Flex justifyContent="space-between" alignItems="center">
+        GitHub
+        <StyledOcticon icon={LinkExternal} color="gray.7"></StyledOcticon>
       </Flex>
-    </BorderBox>
-  ))
+    </Link>
+  )
 }
 
 export default NavItems


### PR DESCRIPTION
## Problem

Primer documentation sites don't make it easy to navigate to the GitHub repository associated with a particular site. For example, https://primer.style/css doesn't have a link to https://github.com/primer/css


## Solution

Doctocat now uses the `repository` field from `package.json` to automatically add a `GitHub` link to the sidebar:

![image](https://user-images.githubusercontent.com/4608155/64290604-3f06fd00-cf1b-11e9-8fe9-8b0cff1a9410.png)

Closes #21 
