### PR TITLE
Replace \ with / in page paths to get Doctocat working on Windows.

### DIFF
--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -51,7 +51,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
           node.parent.relativeDirectory,
           node.parent.name === 'index' ? '/' : node.parent.name,
         )
-        .replace(/\\/g, '/') // Needed to fix paths on windows file systems
+        .replace(/\\/g, '/') // Convert Windows backslash paths to forward slash paths: foo\\bar → foo/bar
 
       const rootAbsolutePath = path.resolve(
         process.cwd(),

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -46,10 +46,12 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
   // Turn every MDX file into a page.
   return Promise.all(
     data.allMdx.nodes.map(async node => {
-      const pagePath = path.join(
-        node.parent.relativeDirectory,
-        node.parent.name === 'index' ? '/' : node.parent.name,
-      )
+      const pagePath = path
+        .join(
+          node.parent.relativeDirectory,
+          node.parent.name === 'index' ? '/' : node.parent.name,
+        )
+        .replace(/\\/g, '/') // Needed to fix paths on windows file systems
 
       const rootAbsolutePath = path.resolve(
         process.cwd(),


### PR DESCRIPTION
I tried to run doctocat in develop mode on my Windows box, and ran into the following issue when I tried to bring up the site at http://localhost:8000 

![image](https://user-images.githubusercontent.com/5487287/64354697-ecd2e400-cfcd-11e9-932a-673fa610727c.png)

It turned out to be related to \ being returned by the nodes representing the mdx files in ```createPages```.

Replacing the \ with / seems to fix the issue for the ```pagePath```, but there may be other places where a similar fix is needed.

It would be interesting to know if other themes or places that use Gatsby's createPages do something similar? If so, maybe we should open an issue in Gatsby.

Also, I didn't test on a non-Windows machine - I think the fix should be fine there, but maybe someone should double-check 😁