### PR TITLE
Fix code example font size on mobile

### DIFF
--- a/theme/src/components/code.js
+++ b/theme/src/components/code.js
@@ -30,18 +30,22 @@ function Code({className, children, live}) {
             className={className}
             mt={0}
             mb={3}
+            p={3}
             border={0}
             style={{...style, overflow: 'auto'}}
           >
-            <Text display="inline-block" p={3} fontFamily="mono" fontSize={1}>
-              {tokens.map((line, i) => (
-                <div key={i} {...getLineProps({line, key: i})}>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({token, key})} />
-                  ))}
-                </div>
-              ))}
-            </Text>
+            {tokens.map((line, i) => (
+              <div key={i} {...getLineProps({line, key: i})}>
+                {line.map((token, key) => (
+                  <Text
+                    key={key}
+                    fontFamily="mono"
+                    fontSize={1}
+                    {...getTokenProps({token, key})}
+                  />
+                ))}
+              </div>
+            ))}
           </BorderBox>
         )}
       </Highlight>


### PR DESCRIPTION
## Problem

The font size of code examples is not consistent on mobile browsers. In some code examples the font size is much too large.

## Solution

This pull request adjusts the way that font-size is applied to code examples. Now, the font size is the same in all code examples across all browsers. I'm guessing the issue might have been a weird inheritance bug.

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4608155/64363584-e7719b80-cfc5-11e9-8b05-73f55150cb6d.PNG" /> | ![IMG_5322](https://user-images.githubusercontent.com/4608155/64364662-39b3bc00-cfc8-11e9-8640-b7d109d4ae0c.PNG) |






