### PR TITLE
Only show mobile search if search is enabled

### DIFF
--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -74,17 +74,21 @@ function Header({isSearchEnabled}) {
             <PrimerNavItems items={primerNavItems} />
           </Box>
           <Flex display={['flex', null, null, 'none']}>
-            <DarkButton
-              aria-label="Search"
-              aria-expanded={isMobileSearchOpen}
-              onClick={() => setIsMobileSearchOpen(true)}
-            >
-              <StyledOcticon icon={SearchIcon} />
-            </DarkButton>
-            <MobileSearch
-              isOpen={isMobileSearchOpen}
-              onDismiss={() => setIsMobileSearchOpen(false)}
-            />
+            {isSearchEnabled ? (
+              <>
+                <DarkButton
+                  aria-label="Search"
+                  aria-expanded={isMobileSearchOpen}
+                  onClick={() => setIsMobileSearchOpen(true)}
+                >
+                  <StyledOcticon icon={SearchIcon} />
+                </DarkButton>
+                <MobileSearch
+                  isOpen={isMobileSearchOpen}
+                  onDismiss={() => setIsMobileSearchOpen(false)}
+                />
+              </>
+            ) : null}
             <DarkButton
               aria-label="Menu"
               aria-expanded={isNavDrawerOpen}


### PR DESCRIPTION
This pull request ensures that we only display the mobile search button in the header if the `isSearchEnabled` prop is set to `true`. This is important for the header to work on primer.style.