### PR TITLE
Fix a few warnings in use-search hook.

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/src/use-search.js
+++ b/theme/src/use-search.js
@@ -1,5 +1,5 @@
 import Fuse from 'fuse.js'
-import {useStaticQuery} from 'gatsby'
+import {graphql, useStaticQuery} from 'gatsby'
 import path from 'path'
 import React from 'react'
 
@@ -37,11 +37,16 @@ function useSearch(query) {
     [data],
   )
 
-  const fuse = new Fuse(list, {
-    threshold: 0.2,
-    keys: ['title', 'rawBody'],
-    tokenize: true,
-  })
+  const fuse = React.useMemo(
+    () =>
+      new Fuse(list, {
+        threshold: 0.2,
+        keys: ['title', 'rawBody'],
+        tokenize: true,
+      }),
+    [list],
+  )
+
   const [results, setResults] = React.useState(list)
 
   React.useEffect(() => {
@@ -50,7 +55,7 @@ function useSearch(query) {
     } else {
       setResults(list)
     }
-  }, [query])
+  }, [query, fuse, list])
 
   return results
 }


### PR DESCRIPTION
- Fixes global graphql usage (thanks @shawnbot !) #86 
- Fixes exhaustive-deps violation in useSearch hook
`53:6  warning  React Hook React.useEffect has missing dependencies: 'fuse' and 'list'. Either include them or remove the dependency array  react-hooks/exhaustive-deps`