### PR TITLE
Add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "start": "yarn workspace docs develop"
+  },
   "workspaces": [
     "theme",
     "docs"


### PR DESCRIPTION
Adds a `start` script to the root because typing `yarn workspace docs develop` is really annoying :) 