### PR TITLE
Bump react dep

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -8,13 +8,13 @@
   },
   "devDependencies": {
     "gatsby": "^2.13.52",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   },
   "peerDependencies": {
     "gatsby": "2.x",
     "react": "16.9.x",
-    "react-dom": "16.8.x"
+    "react-dom": "16.9.x"
   },
   "dependencies": {
     "@babel/preset-env": "^7.5.5",

--- a/theme/package.json
+++ b/theme/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "gatsby": "2.x",
-    "react": "16.8.x",
+    "react": "16.9.x",
     "react-dom": "16.8.x"
   },
   "dependencies": {


### PR DESCRIPTION
Primer Components and Gatsby both rely on the `^16.9.0` range of `react` and `react-dom`, which may be causing some peer dependency issues in projects using those libraries. Bumping up to `^16.9.0`