### PR TITLE
Skip link to allow user to skip to page content.

### DIFF
--- a/theme/src/components/container.js
+++ b/theme/src/components/container.js
@@ -3,7 +3,7 @@ import React from 'react'
 
 function Container({children}) {
   return (
-    <Box width="100%" maxWidth={960} p={5} mx="auto">
+    <Box id="skip-nav" width="100%" maxWidth={960} p={5} mx="auto">
       {children}
     </Box>
   )

--- a/theme/src/components/skip-link.js
+++ b/theme/src/components/skip-link.js
@@ -1,0 +1,38 @@
+import {Link} from '@primer/components'
+import styled from 'styled-components'
+import React from 'react'
+
+function SkipLinkBase({...rest}) {
+  return (
+    <Link
+      {...rest}
+      backgroundColor="blue.6"
+      color="white"
+      p={3}
+      href="#skip-nav"
+      fontSize={14}
+    >
+      Skip to content
+    </Link>
+  )
+}
+
+const SkipLink = styled(SkipLinkBase)`
+  z-index: 20;
+  width: auto;
+  height: auto;
+  clip: auto;
+  position: absolute;
+  overflow: hidden;
+
+  &:not(:focus) {
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    padding: 0;
+  }
+`
+
+export default SkipLink

--- a/theme/src/components/skip-link.js
+++ b/theme/src/components/skip-link.js
@@ -2,15 +2,15 @@ import {Link} from '@primer/components'
 import styled from 'styled-components'
 import React from 'react'
 
-function SkipLinkBase({...rest}) {
+function SkipLinkBase(props) {
   return (
     <Link
-      {...rest}
+      {...props}
       backgroundColor="blue.6"
       color="white"
       p={3}
       href="#skip-nav"
-      fontSize={14}
+      fontSize={1}
     >
       Skip to content
     </Link>
@@ -24,6 +24,11 @@ const SkipLink = styled(SkipLinkBase)`
   clip: auto;
   position: absolute;
   overflow: hidden;
+
+  // The following rules are to ensure that the element
+  // is visually hidden, unless it has focus. This is the recommended
+  // way to hide content from:
+  // https://webaim.org/techniques/css/invisiblecontent/#techniques
 
   &:not(:focus) {
     clip: rect(1px, 1px, 1px, 1px);

--- a/theme/src/components/wrap-page-element.js
+++ b/theme/src/components/wrap-page-element.js
@@ -1,8 +1,14 @@
 import {BaseStyles} from '@primer/components'
 import React from 'react'
+import SkipLink from './skip-link'
 
 function wrapPageElement({element}) {
-  return <BaseStyles>{element}</BaseStyles>
+  return (
+    <BaseStyles>
+      <SkipLink />
+      {element}
+    </BaseStyles>
+  )
 }
 
 export default wrapPageElement


### PR DESCRIPTION
Github.com:
![image](https://user-images.githubusercontent.com/5487287/65707707-14601e00-e05b-11e9-97a7-b59a29c514f2.png)

Doctocat:
![image](https://user-images.githubusercontent.com/5487287/65707768-3194ec80-e05b-11e9-8cf8-6aafd205a231.png)

Closes #82 
Saves 21 tabs to get to main content on Doctocat site!