### PR TITLE
Fix bug where user-agent color is too dark in Edge

### DIFF
--- a/theme/src/components/dark-text-input.js
+++ b/theme/src/components/dark-text-input.js
@@ -17,10 +17,11 @@ const DarkTextInput = styled(TextInput)`
     box-shadow: none;
   }
 
-  &::-webkit-input-placeholder {
+&::placeholder {
     // Needed to fix Chromium-based Edge
     // where user-agent color is too dark.
-    color: rgb(117, 117, 117);
+    color: inherit;
+    opacity: 0.6; // inceases contrast ratio to 4.52
   }
 `
 export default DarkTextInput

--- a/theme/src/components/dark-text-input.js
+++ b/theme/src/components/dark-text-input.js
@@ -16,5 +16,11 @@ const DarkTextInput = styled(TextInput)`
     outline: none;
     box-shadow: none;
   }
+
+  &::-webkit-input-placeholder {
+    // Needed to fix Chromium-based Edge
+    // where user-agent color is too dark.
+    color: rgb(117, 117, 117);
+  }
 `
 export default DarkTextInput


### PR DESCRIPTION
In Chromium-based Edge, the placeholder text color has an alpha value, which causes issues for the dark text input used in the Doctocat search:

![image](https://user-images.githubusercontent.com/5487287/65769979-0b2a8c00-e103-11e9-90f9-b9ec8c8917c7.png)

This PR sets the color to be the Chrome user-agent value to get the same behavior in both browsers.