### PR TITLE
Fix linked Headings from being covered by the main header

### DIFF
--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -9,15 +9,10 @@ import styled from 'styled-components'
 const StyledHeading = styled(Heading)`
   margin-top: ${themeGet('space.4')};
   margin-bottom: ${themeGet('space.3')};
-  
+
   // Makes sure links to Headings are not covered by the fixed "main" header
   // header (66px) + margin (24px) = 90px
-  &:target::before {
-    content: '';
-    display: block;
-    height: 90px;
-    margin-top: -90px;
-  }
+  scroll-margin-top: 90px;
 
   & .octicon-link {
     visibility: hidden;

--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -9,6 +9,15 @@ import styled from 'styled-components'
 const StyledHeading = styled(Heading)`
   margin-top: ${themeGet('space.4')};
   margin-bottom: ${themeGet('space.3')};
+  
+  // Makes sure links to Headings are not covered by the fixed "main" header
+  // header (66px) + margin (24px) = 90px
+  &:target::before {
+    content: '';
+    display: block;
+    height: 90px;
+    margin-top: -90px;
+  }
 
   & .octicon-link {
     visibility: hidden;


### PR DESCRIPTION
This fixes the "scroll position" when linking to a `Heading`. Currently the `Heading` gets covered by the main header.

Before | After
--- | ---
![link-before](https://user-images.githubusercontent.com/378023/71567350-b9c6da00-2b01-11ea-8036-2b6084de3c46.gif) | ![link-after](https://user-images.githubusercontent.com/378023/71567351-ba5f7080-2b01-11ea-83e7-f33c648b5842.gif)

🔍 [Preview](https://doctocat-git-fix-link-to-headings.primer.now.sh/doctocat/usage/customization#site-metadata)

It uses the [`scroll-margin-top`](https://css-tricks.com/fixed-headers-and-jump-links-the-solution-is-scroll-margin-top/) property to tell the browser to add a bit more extra margin when scrolling to Headings.