### PR TITLE
Remove experimental warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,4 @@
 [![npm](https://img.shields.io/npm/v/@primer/gatsby-theme-doctocat)](https://www.npmjs.com/package/@primer/gatsby-theme-doctocat)
 [![Publish workflow](https://github.com/primer/doctocat/workflows/Publish/badge.svg)](https://github.com/primer/doctocat/actions)
 
-**⚠️ WARNING! Doctocat is still experimental.**
-
 Doctocat makes it easy to set up a documentation site so you can focus on what's important: _writing docs_. Check out [primer.style/doctocat](https://primer.style/doctocat) to get started.

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -2,15 +2,9 @@
 title: Doctocat
 ---
 
-import {Flash, StyledOcticon} from '@primer/components'
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
-import {Alert} from '@primer/octicons-react'
 
 export default HeroLayout
-
-<Flash scheme="yellow" mb={3}>
-  <StyledOcticon icon={Alert} mr={2} /> Doctocat is still experimental.
-</Flash>
 
 Doctocat makes it easy to set up a documentation site so you can focus on what's important: _writing docs_.
 


### PR DESCRIPTION
Doctocat is no longer "experimental". It now powers all of our `primer.style` documentation sites.