### PR TITLE
Fix broken page when resizing with drawer open

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -48,6 +48,7 @@
     "github-slugger": "^1.2.1",
     "html-react-parser": "^0.9.1",
     "jest": "^24.9.0",
+    "lodash.debounce": "4.0.8",
     "lodash.uniqby": "^4.7.0",
     "pkg-up": "^3.1.0",
     "pluralize": "^8.0.0",

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -7,16 +7,20 @@ import {
 } from '@primer/octicons-react'
 import {Link as GatsbyLink} from 'gatsby'
 import React from 'react'
+import {ThemeContext} from 'styled-components'
 import primerNavItems from '../primer-nav.yml'
 import useSiteMetadata from '../use-site-metadata'
 import DarkButton from './dark-button'
-import NavDrawer from './nav-drawer'
+import NavDrawer, {useNavDrawerState} from './nav-drawer'
 import NavDropdown, {NavDropdownItem} from './nav-dropdown'
 import Search from './search'
 import MobileSearch from './mobile-search'
 
 function Header({isSearchEnabled}) {
-  const [isNavDrawerOpen, setIsNavDrawerOpen] = React.useState(false)
+  const theme = React.useContext(ThemeContext)
+  const [isNavDrawerOpen, setIsNavDrawerOpen] = useNavDrawerState(
+    theme.breakpoints[2],
+  )
   const [isMobileSearchOpen, setIsMobileSearchOpen] = React.useState(false)
   const siteMetadata = useSiteMetadata()
   return (

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -22,7 +22,7 @@ function useNavDrawerState(breakpoint) {
     if (window.innerWidth >= breakpoint) {
       setOpen(false)
     }
-  }, [isOpen, setOpen])
+  }, [setOpen])
 
   const debouncedOnResize = React.useCallback(debounce(onResize, 250), [
     onResize,

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -1,6 +1,7 @@
 import {BorderBox, Flex, Link, StyledOcticon, Text} from '@primer/components'
 import {ChevronDown, ChevronUp, X} from '@primer/octicons-react'
 import {Link as GatsbyLink} from 'gatsby'
+import debounce from 'lodash.debounce'
 import React from 'react'
 import navItems from '../nav.yml'
 import primerNavItems from '../primer-nav.yml'
@@ -9,7 +10,6 @@ import DarkButton from './dark-button'
 import Details from './details'
 import Drawer from './drawer'
 import NavItems from './nav-items'
-import debounce from 'lodash.debounce'
 
 function useNavDrawerState(breakpoint) {
   // Handle string values from themes with units at the end

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -19,7 +19,7 @@ function useNavDrawerState(breakpoint) {
   const [isOpen, setOpen] = React.useState(false)
 
   const onResize = React.useCallback(() => {
-    if (window.innerWidth >= breakpoint && isOpen) {
+    if (window.innerWidth >= breakpoint) {
       setOpen(false)
     }
   }, [isOpen, setOpen])
@@ -29,13 +29,15 @@ function useNavDrawerState(breakpoint) {
   ])
 
   React.useEffect(() => {
-    window.addEventListener('resize', debouncedOnResize)
-    return () => {
-      // cancel any debounced invocation of the resize handler
-      debouncedOnResize.cancel()
-      window.removeEventListener('resize', debouncedOnResize)
+    if (isOpen) {
+      window.addEventListener('resize', debouncedOnResize)
+      return () => {
+        // cancel any debounced invocation of the resize handler
+        debouncedOnResize.cancel()
+        window.removeEventListener('resize', debouncedOnResize)
+      }
     }
-  }, [debouncedOnResize])
+  }, [isOpen, debouncedOnResize])
 
   return [isOpen, setOpen]
 }

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -9,6 +9,36 @@ import DarkButton from './dark-button'
 import Details from './details'
 import Drawer from './drawer'
 import NavItems from './nav-items'
+import debounce from 'lodash.debounce'
+
+function useNavDrawerState(breakpoint) {
+  // Handle string values from themes with units at the end
+  if (typeof breakpoint === 'string') {
+    breakpoint = parseInt(breakpoint, 10)
+  }
+  const [isOpen, setOpen] = React.useState(false)
+
+  const onResize = React.useCallback(() => {
+    if (window.innerWidth >= breakpoint && isOpen) {
+      setOpen(false)
+    }
+  }, [isOpen, setOpen])
+
+  const debouncedOnResize = React.useCallback(debounce(onResize, 250), [
+    onResize,
+  ])
+
+  React.useEffect(() => {
+    window.addEventListener('resize', debouncedOnResize)
+    return () => {
+      // cancel any debounced invocation of the resize handler
+      debouncedOnResize.cancel()
+      window.removeEventListener('resize', debouncedOnResize)
+    }
+  }, [debouncedOnResize])
+
+  return [isOpen, setOpen]
+}
 
 function NavDrawer({isOpen, onDismiss}) {
   const siteMetadata = useSiteMetadata()
@@ -125,3 +155,4 @@ function PrimerNavItems({items}) {
 }
 
 export default NavDrawer
+export {useNavDrawerState}

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -11,7 +11,7 @@ import Details from './details'
 import Drawer from './drawer'
 import NavItems from './nav-items'
 
-function useNavDrawerState(breakpoint) {
+export function useNavDrawerState(breakpoint) {
   // Handle string values from themes with units at the end
   if (typeof breakpoint === 'string') {
     breakpoint = parseInt(breakpoint, 10)
@@ -157,4 +157,3 @@ function PrimerNavItems({items}) {
 }
 
 export default NavDrawer
-export {useNavDrawerState}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8309,6 +8309,11 @@ lodash.bind@^4.1.4:
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
   integrity sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=
 
+lodash.debounce@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"


### PR DESCRIPTION
Copied from https://github.com/primer/components/issues/691:

> Hi friends, I think I found a little bug in the documentation website, which results in the page becoming unclickable.
> 
> **Reproduction Steps:**
> Step 1. Open https://primer.style/components/ on PC
> Step 2. Resize window until hamburger menu on top-right appears, then click on it.
> Step 3. Without pressing anything else, resize the window back wide enough that the hamburger menu disappears, the page is now unclickable, unscrollable, etc.

This happens because we open an overlay on the page when opening the drawer, but resizing the window only causes the drawer element to disappear because of breakpoints, and we don't ever actually close the drawer. This PR adds a hook for the drawer that ensures that it gets closed when the window is resized past the given breakpoint.

@colebemis Curious how you feel about this solution? Would be fine with alternatives if you have thoughts.