### PR TITLE
Fix "cannot read property 'title' of undefined" after HMR

### DIFF
--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -86,7 +86,6 @@ async function fetchContributors(repo, filePath, accessToken) {
   const hash = `${repo.user}/${repo.project}/${filePath}`
   const cached = CONTRIBUTOR_CACHE.get(hash)
   if (cached) {
-    console.debug('found something in the cache. whee!')
     return cached
   }
 

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -14,6 +14,9 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
       allMdx {
         nodes {
           fileAbsolutePath
+          frontmatter {
+            title
+          }
           tableOfContents
           parent {
             ... on File {
@@ -64,9 +67,11 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
           editUrl,
           contributors,
           tableOfContents: node.tableOfContents,
-          // We don't need to add `frontmatter` to the page context here
-          // because gatsby-plugin-mdx automatically does that.
-          // Source: https://git.io/fjQDa
+          // Note: gatsby-plugin-mdx should insert frontmatter
+          // for us here, and does on the first build,
+          // but when HMR kicks in the frontmatter is lost.
+          // The solution is to include it here explicitly.
+          frontmatter: node.frontmatter
         },
       })
     }),


### PR DESCRIPTION
Something about the way HMR runs is causing every build except the first one to have a missing `frontmatter` property in the page context; this PR adds the frontmatter explicitly, ensuring it always exists.

This PR also fine tunes the way we look up contributor data from GitHub:

* If `GITHUB_TOKEN` is not set, no API call will be made
* Results from the API are stored in an in-memory cache to cut down on requests during development