### PR TITLE
Updates for Component Refresh

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.16.9",
+  "version": "0.16.10",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/src/components/dark-button.js
+++ b/theme/src/components/dark-button.js
@@ -5,6 +5,7 @@ const DarkButton = styled(ButtonOutline)`
   color: ${themeGet('colors.blue.2')};
   background-color: transparent;
   border: 1px solid ${themeGet('colors.gray.7')};
+  box-shadow: none;
 `
 
 export default DarkButton

--- a/theme/src/components/dark-text-input.js
+++ b/theme/src/components/dark-text-input.js
@@ -10,6 +10,7 @@ const DarkTextInput = styled(TextInput)`
   color: ${themeGet('colors.white')};
   background-color: rgba(255, 255, 255, 0.07);
   border: 1px solid transparent;
+  box-shadow: none;
 
   &:focus {
     border: 1px solid rgba(255, 255, 255, 0.15);


### PR DESCRIPTION
This PR updates the dark inputs and buttons to set no box-shadow. The visual refresh in Primer Components adds some box-shadows that look weird with these dark variants. 

We'll need to ship these changes now, so that we can use the new doctocat version in the Primer Components visual refresh PR 😸It's safe to ship these now without updating Primer Components in this repo because there was no box-shadow before, so adding `box-shadow: none` doesn't make any difference.