### PR TITLE
Add support for `noInline` on live code editors

### DIFF
--- a/docs/content/usage/live-code.mdx
+++ b/docs/content/usage/live-code.mdx
@@ -78,7 +78,7 @@ export default function LivePreviewWrapper({children}) {
 }
 ```
 
-## No-Inline
+## No-inline
 
 By default, live previews treat your code as a single JSX expression to be rendered. If you want to include more complex code, use the `noinline` attribute on the code block, and render components with the exported `render` function:
 

--- a/docs/content/usage/live-code.mdx
+++ b/docs/content/usage/live-code.mdx
@@ -77,3 +77,41 @@ export default function LivePreviewWrapper({children}) {
   )
 }
 ```
+
+## No-Inline
+
+By default, live previews treat your code as a single JSX expression to be rendered. If you want to include more complex code, use the `noinline` attribute on the code block, and render components with the exported `render` function:
+
+````markdown
+```javascript live noinline
+function DemoApp() {
+  const [count, setCount] = React.useState(0)
+
+  return (
+    <div>
+      <button onClick={() => setCount(n => n - 1)}>-</button>
+      {count}
+      <button onClick={() => setCount(n => n + 1)}>+</button>
+    </div>
+  )
+}
+
+render(<DemoApp />)
+```
+````
+
+```javascript live noinline
+function DemoApp() {
+  const [count, setCount] = React.useState(0)
+
+  return (
+    <div style={{textAlign: 'center'}}>
+      <button onClick={() => setCount(n => n - 1)}>-</button>
+      {count}
+      <button onClick={() => setCount(n => n + 1)}>+</button>
+    </div>
+  )
+}
+
+render(<DemoApp />)
+```

--- a/theme/src/components/code.js
+++ b/theme/src/components/code.js
@@ -5,12 +5,12 @@ import React from 'react'
 import ClipboardCopy from './clipboard-copy'
 import LiveCode from './live-code'
 
-function Code({className, children, live}) {
+function Code({className, children, live, noinline}) {
   const language = className ? className.replace(/language-/, '') : ''
   const code = children.trim()
 
   if (live) {
-    return <LiveCode code={code} language={language} />
+    return <LiveCode code={code} language={language} noinline={noinline} />
   }
 
   return (

--- a/theme/src/components/live-code.js
+++ b/theme/src/components/live-code.js
@@ -34,7 +34,7 @@ function wrapWithFragment(jsx) {
   return `<React.Fragment>${jsx}</React.Fragment>`
 }
 
-function LiveCode({code, language}) {
+function LiveCode({code, language, noinline}) {
   const theme = React.useContext(ThemeContext)
 
   return (
@@ -47,6 +47,7 @@ function LiveCode({code, language}) {
         scope={scope}
         code={code}
         transformCode={languageTransformers[language]}
+        noInline={noinline}
       >
         <LivePreviewWrapper>
           <LivePreview />


### PR DESCRIPTION
It would be nice to be able to include more complex examples on documentation pages; for this, it would be useful to have access to the `noInline` prop. Here's an example of how this could be useful from some documentation I'm working on:

```javascript
function CaretSelector(props) {
  return [
    'top',
    'bottom',
    'left',
    'right',
    'bottom-left',
    'bottom-right',
    'top-left',
    'top-right',
    'left-bottom',
    'left-top',
    'right-bottom',
    'right-top'
  ].map((dir) => (
    <>
      <input type="radio" name="caret" 
       value={dir} key={dir} selected={dir === props.current}
       onClick={() => props.onChange(dir)} /> {dir}
    </>
  ))
}

function Demo(props) {
  const [pos, setPos] = React.useState('top')

  return (
    <Relative>
      <CaretSelector current={pos} onChange={setPos} />
      <Text textAlign="center" display="block">
        <ButtonPrimary>Hello!</ButtonPrimary>
      </Text>

      <Popover open={true} relative>
        <Popover.Content mt={2} caret={pos}>
          <Heading fontSize={2}>Popover heading</Heading>
          <Text as="p">Message about this particular piece of UI.</Text>
          <Button>Got it!</Button>
        </Popover.Content>
      </Popover>
    </Relative>
  )
}

render(<Demo />)
```

Here is a live example in this PR's preview deployment: https://doctocat-git-mkt-enable-no-inline-for-live-code.primer.now.sh/doctocat/usage/live-code#no-inline