### PR TITLE
Update Octicons link in Primer nav

### DIFF
--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -5,7 +5,7 @@
     - title: Interface guidelines
       url: https://primer.style/design
     - title: Octicons
-      url: https://octicons.github.com
+      url: https://primer.style/octicons
     - title: Prototyping
       url: https://primer.style/css/tools/prototyping
     - title: Presentations


### PR DESCRIPTION
This updates the Octicons link in the header from `octicons.github.com` to `primer.style/octicons`

![image](https://user-images.githubusercontent.com/4608155/76470849-60efa980-63ae-11ea-97e2-61ebf54385fa.png)
