### PR TITLE
Use @primer/components 16.1.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "now-build": "npm run build"
   },
   "dependencies": {
+    "@primer/components": "^16.1.0",
     "@primer/css": "^12.4.1",
     "@primer/gatsby-theme-doctocat": "*",
     "gatsby": "^2.13.52",

--- a/theme/package.json
+++ b/theme/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-react": "^7.0.0",
     "@mdx-js/mdx": "^1.0.21",
     "@mdx-js/react": "^1.0.21",
-    "@primer/components": "^15.3.0",
+    "@primer/components": "^16.1.0",
     "@primer/octicons-react": "^9.1.1",
     "@styled-system/theme-get": "^5.0.12",
     "@testing-library/jest-dom": "^4.1.0",

--- a/theme/src/components/live-code.js
+++ b/theme/src/components/live-code.js
@@ -42,6 +42,7 @@ function LiveCode({code, language, noinline}) {
       as={Flex}
       flexDirection="column"
       mb={3}
+      css={{overflow: 'hidden'}}
     >
       <LiveProvider
         scope={scope}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,10 +1100,10 @@
     hey-listen "^1.0.8"
     style-value-types "^3.1.6"
 
-"@primer/components@^15.3.0":
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/@primer/components/-/components-15.3.0.tgz#dc2ca5bbe21e39d002fe672633b30a94d913c0e3"
-  integrity sha512-Y1aOhowuAYU4fpq1++g0Kba6vzUPj2tcTLWXe7UFJVWETSX9tkUyaFt6FDA+qsdU9QlPONgbSM4evsG8xKokpw==
+"@primer/components@^16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@primer/components/-/components-16.1.0.tgz#29d6dc7e1d85f23402ea4aa802e2fc81fdfd02e6"
+  integrity sha512-bSvrUYZkItgGAxnrYuIoeN9Cydd7HmAMQOrawsQ6NYPTlsDbZQKbmmew2cBf7mXA06KfJgj7CQdlE49faoW4lg==
   dependencies:
     "@primer/octicons-react" "^9.2.0"
     "@reach/dialog" "0.3.0"


### PR DESCRIPTION
This PR updates the version of @primer/components that Doctocat uses to `16.1.0`. Version `16` of @primer/components introduced a visual refresh for components like buttons and inputs ✨ 