### PR TITLE
Update table of contents

### DIFF
--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -71,7 +71,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
           // for us here, and does on the first build,
           // but when HMR kicks in the frontmatter is lost.
           // The solution is to include it here explicitly.
-          frontmatter: node.frontmatter
+          // frontmatter: node.frontmatter
         },
       })
     }),

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -16,6 +16,8 @@ import NavDropdown, {NavDropdownItem} from './nav-dropdown'
 import Search from './search'
 import MobileSearch from './mobile-search'
 
+export const HEADER_HEIGHT = 66
+
 function Header({isSearchEnabled}) {
   const theme = React.useContext(ThemeContext)
   const [isNavDrawerOpen, setIsNavDrawerOpen] = useNavDrawerState(
@@ -26,7 +28,7 @@ function Header({isSearchEnabled}) {
   return (
     <Sticky>
       <Flex
-        py={3}
+        height={HEADER_HEIGHT}
         px={[3, null, null, 4]}
         alignItems="center"
         justifyContent="space-between"

--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -5,10 +5,12 @@ import GithubSlugger from 'github-slugger'
 import React from 'react'
 import textContent from 'react-addons-text-content'
 import styled from 'styled-components'
+import {HEADER_HEIGHT} from './header'
 
 const StyledHeading = styled(Heading)`
   margin-top: ${themeGet('space.4')};
   margin-bottom: ${themeGet('space.3')};
+  scroll-margin-top: ${HEADER_HEIGHT + 24}px;
 
   & .octicon-link {
     visibility: hidden;

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -7,7 +7,9 @@ import {
   Position,
   Text,
   Details,
+  StyledOcticon,
 } from '@primer/components'
+import {ChevronDown, ChevronRight} from '@primer/octicons-react'
 import React from 'react'
 import Head from './head'
 import Header, {HEADER_HEIGHT} from './header'
@@ -82,16 +84,24 @@ function Layout({children, pageContext}) {
             ) : null}
             {pageContext.tableOfContents.items ? (
               <Box display={['block', null, 'none']} mb={3}>
-                <details>
-                  <Text as="summary" fontWeight="bold">
-                    Contents
-                  </Text>
-                  <Box pt={1}>
-                    <TableOfContents
-                      items={pageContext.tableOfContents.items}
-                    />
-                  </Box>
-                </details>
+                <Details>
+                  {({open}) => (
+                    <>
+                      <Text as="summary" fontWeight="bold">
+                        <StyledOcticon
+                          icon={open ? ChevronDown : ChevronRight}
+                          mr={2}
+                        />
+                        Contents
+                      </Text>
+                      <Box pt={1}>
+                        <TableOfContents
+                          items={pageContext.tableOfContents.items}
+                        />
+                      </Box>
+                    </>
+                  )}
+                </Details>
               </Box>
             ) : null}
             {children}

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,9 +1,15 @@
-import {MDXContext} from '@mdx-js/react'
-import {Box, Flex} from '@primer/components'
+import {
+  BorderBox,
+  Box,
+  Flex,
+  Grid,
+  Heading,
+  Position,
+  Text,
+} from '@primer/components'
 import React from 'react'
-import Container from './container'
 import Head from './head'
-import Header from './header'
+import Header, {HEADER_HEIGHT} from './header'
 import PageFooter from './page-footer'
 import Sidebar from './sidebar'
 import SourceLink from './source-link'
@@ -11,7 +17,6 @@ import StatusLabel from './status-label'
 import TableOfContents from './table-of-contents'
 
 function Layout({children, pageContext}) {
-  const {h1: H1 = 'h1'} = React.useContext(MDXContext)
   const {
     title,
     description,
@@ -28,30 +33,54 @@ function Layout({children, pageContext}) {
         <Box display={['none', null, null, 'block']}>
           <Sidebar />
         </Box>
-        <Container>
-          <H1>{title}</H1>
-
-          {status || source ? (
-            <Flex mb={4} alignItems="center">
-              {status ? <StatusLabel status={status} /> : null}
-              <Box mx="auto" />
-              {source ? <SourceLink href={source} /> : null}
-            </Flex>
-          ) : null}
-
+        <Grid
+          gridTemplateColumns="minmax(0, 65ch) 260px"
+          gridTemplateAreas='"heading ." "content table-of-contents"'
+          gridColumnGap={7}
+          gridRowGap={3}
+          mx="auto"
+          p={7}
+          css={{alignItems: 'start', alignSelf: 'start'}}
+        >
+          <BorderBox
+            css={{gridArea: 'heading'}}
+            border={0}
+            borderBottom={1}
+            borderRadius={0}
+            pb={2}
+          >
+            <Heading>{title}</Heading>
+          </BorderBox>
           {pageContext.tableOfContents.items ? (
-            <TableOfContents items={pageContext.tableOfContents.items} />
+            <Position
+              css={{gridArea: 'table-of-contents', overflow: 'auto'}}
+              position="sticky"
+              top={HEADER_HEIGHT + 24}
+              maxHeight={`calc(100vh - ${HEADER_HEIGHT}px - 24px)`}
+            >
+              <Text display="inline-block" fontWeight="bold" mb={1}>
+                Contents
+              </Text>
+              <TableOfContents items={pageContext.tableOfContents.items} />
+            </Position>
           ) : null}
-
-          {children}
-
-          <PageFooter
-            editUrl={pageContext.editUrl}
-            contributors={pageContext.contributors.concat(
-              additionalContributors.map(login => ({login})),
-            )}
-          />
-        </Container>
+          <Box css={{gridArea: 'content'}}>
+            {status || source ? (
+              <Flex mb={3} alignItems="center">
+                {status ? <StatusLabel status={status} /> : null}
+                <Box mx="auto" />
+                {source ? <SourceLink href={source} /> : null}
+              </Flex>
+            ) : null}
+            {children}
+            <PageFooter
+              editUrl={pageContext.editUrl}
+              contributors={pageContext.contributors.concat(
+                additionalContributors.map(login => ({login})),
+              )}
+            />
+          </Box>
+        </Grid>
       </Flex>
     </Flex>
   )

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -69,7 +69,7 @@ function Layout({children, pageContext}) {
               maxHeight={`calc(100vh - ${HEADER_HEIGHT}px - 24px)`}
             >
               <Text display="inline-block" fontWeight="bold" mb={1}>
-                Contents
+                Table of contents
               </Text>
               <TableOfContents items={pageContext.tableOfContents.items} />
             </Position>
@@ -92,7 +92,7 @@ function Layout({children, pageContext}) {
                           icon={open ? ChevronDown : ChevronRight}
                           mr={2}
                         />
-                        Contents
+                        Table of contents
                       </Text>
                       <Box pt={1}>
                         <TableOfContents

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -37,7 +37,7 @@ function Layout({children, pageContext}) {
         <Grid
           id="skip-nav"
           maxWidth="100%"
-          gridTemplateColumns={['100%', null, null, 'minmax(0, 65ch) 220px']}
+          gridTemplateColumns={['100%', null, 'minmax(0, 65ch) 220px']}
           gridTemplateAreas={[
             '"heading" "content"',
             null,

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -34,6 +34,7 @@ function Layout({children, pageContext}) {
           <Sidebar />
         </Box>
         <Grid
+          id="skip-nav"
           gridTemplateColumns="minmax(0, 65ch) 260px"
           gridTemplateAreas='"heading ." "content table-of-contents"'
           gridColumnGap={7}

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -6,6 +6,7 @@ import {
   Heading,
   Position,
   Text,
+  Details,
 } from '@primer/components'
 import React from 'react'
 import Head from './head'
@@ -35,12 +36,17 @@ function Layout({children, pageContext}) {
         </Box>
         <Grid
           id="skip-nav"
-          gridTemplateColumns="minmax(0, 65ch) 260px"
-          gridTemplateAreas='"heading ." "content table-of-contents"'
-          gridColumnGap={7}
+          maxWidth="100%"
+          gridTemplateColumns={['100%', null, null, 'minmax(0, 65ch) 220px']}
+          gridTemplateAreas={[
+            '"heading" "content"',
+            null,
+            '"heading ." "content table-of-contents"',
+          ]}
+          gridColumnGap={[null, null, 6, 7]}
           gridRowGap={3}
           mx="auto"
-          p={7}
+          p={[5, 6, null, 7]}
           css={{alignItems: 'start', alignSelf: 'start'}}
         >
           <BorderBox
@@ -54,6 +60,7 @@ function Layout({children, pageContext}) {
           </BorderBox>
           {pageContext.tableOfContents.items ? (
             <Position
+              display={['none', null, 'block']}
               css={{gridArea: 'table-of-contents', overflow: 'auto'}}
               position="sticky"
               top={HEADER_HEIGHT + 24}
@@ -72,6 +79,20 @@ function Layout({children, pageContext}) {
                 <Box mx="auto" />
                 {source ? <SourceLink href={source} /> : null}
               </Flex>
+            ) : null}
+            {pageContext.tableOfContents.items ? (
+              <Box display={['block', null, 'none']} mb={3}>
+                <details>
+                  <Text as="summary" fontWeight="bold">
+                    Contents
+                  </Text>
+                  <Box pt={1}>
+                    <TableOfContents
+                      items={pageContext.tableOfContents.items}
+                    />
+                  </Box>
+                </details>
+              </Box>
             ) : null}
             {children}
             <PageFooter

--- a/theme/src/components/sidebar.js
+++ b/theme/src/components/sidebar.js
@@ -1,38 +1,31 @@
 import {BorderBox, Flex, Position} from '@primer/components'
 import React from 'react'
-import Measure from 'react-measure'
 import navItems from '../nav.yml'
+import {HEADER_HEIGHT} from './header'
 import NavItems from './nav-items'
 
 function Sidebar() {
-  const [top, setTop] = React.useState(0)
-
   return (
-    <Measure bounds={true} onResize={rect => setTop(rect.bounds.top)}>
-      {({measureRef}) => (
-        <Position
-          ref={measureRef}
-          position="sticky"
-          top={top}
-          height={`calc(100vh - ${top}px)`}
-          minWidth={260}
-          color="gray.8"
-          bg="gray.0"
-        >
-          <BorderBox
-            border={0}
-            borderRight={1}
-            borderRadius={0}
-            height="100%"
-            style={{overflow: 'auto'}}
-          >
-            <Flex flexDirection="column">
-              <NavItems items={navItems} />
-            </Flex>
-          </BorderBox>
-        </Position>
-      )}
-    </Measure>
+    <Position
+      position="sticky"
+      top={HEADER_HEIGHT}
+      height={`calc(100vh - ${HEADER_HEIGHT}px)`}
+      minWidth={260}
+      color="gray.8"
+      bg="gray.0"
+    >
+      <BorderBox
+        border={0}
+        borderRight={1}
+        borderRadius={0}
+        height="100%"
+        style={{overflow: 'auto'}}
+      >
+        <Flex flexDirection="column">
+          <NavItems items={navItems} />
+        </Flex>
+      </BorderBox>
+    </Position>
   )
 }
 

--- a/theme/src/components/table-of-contents.js
+++ b/theme/src/components/table-of-contents.js
@@ -1,23 +1,25 @@
-import {MDXContext} from '@mdx-js/react'
+import {Box, Link} from '@primer/components'
 import React from 'react'
 
-function TableOfContents({items}) {
-  const {
-    ul: List = 'ul',
-    li: ListItem = 'li',
-    a: Link = 'a',
-  } = React.useContext(MDXContext)
-
+function TableOfContents({items, depth}) {
   return (
-    <List>
+    <Box as="ul" m={0} p={0} css={{listStyle: 'none'}}>
       {items.map(item => (
-        <ListItem key={item.url}>
-          <Link href={item.url}>{item.title}</Link>
-          {item.items ? <TableOfContents items={item.items} /> : null}
-        </ListItem>
+        <Box as="li" key={item.url} pl={depth * 16}>
+          <Link display="inline-block" py={1} href={item.url} color="gray.6">
+            {item.title}
+          </Link>
+          {item.items ? (
+            <TableOfContents items={item.items} depth={depth + 1} />
+          ) : null}
+        </Box>
       ))}
-    </List>
+    </Box>
   )
+}
+
+TableOfContents.defaultProps = {
+  depth: 0,
 }
 
 export default TableOfContents

--- a/theme/src/components/table-of-contents.js
+++ b/theme/src/components/table-of-contents.js
@@ -5,7 +5,7 @@ function TableOfContents({items, depth}) {
   return (
     <Box as="ul" m={0} p={0} css={{listStyle: 'none'}}>
       {items.map(item => (
-        <Box as="li" key={item.url} pl={depth * 16}>
+        <Box as="li" key={item.url} pl={depth > 0 ? 3 : 0}>
           <Link display="inline-block" py={1} href={item.url} color="gray.6">
             {item.title}
           </Link>


### PR DESCRIPTION
## Problem

The table of contents takes up a lot of room at the top of our Primer documentation pages:

![image](https://user-images.githubusercontent.com/4608155/78165289-f3a8c480-73ff-11ea-9732-5ad6d9d4f16c.png)


## Solution

This PR moves the table of contents into a sticky sidebar so it doesn't push the main content below the fold:

![ezgif com-optimize (3)](https://user-images.githubusercontent.com/4608155/78165076-a593c100-73ff-11ea-8ede-6a6208fe6c6a.gif)

On mobile, the table of contents collapses into a details element:

| Collapsed | Expanded |
| --- | --- | 
| ![primer-components-lak1zacvj now sh_components_core-concepts(iPhone 5_SE)](https://user-images.githubusercontent.com/4608155/78165945-eb04be00-7400-11ea-9f59-5859c9006721.png) | ![primer-components-lak1zacvj now sh_components_core-concepts(iPhone 5_SE) (1)](https://user-images.githubusercontent.com/4608155/78166003-ffe15180-7400-11ea-9f88-f88d75fb5d4a.png) |

---

Part of #120 