### PR TITLE
Enable fetching contributors without token on deploy

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "main": "index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
f25f74decd21649592c074c9e97624a614406525 introduced a check insuring that `GITHUB_TOKEN` was set before fetching contributor data from GitHub, as running in dev mode without a token generated a lot of requests which started timing out, slowing the build, and logging a lot of errors. However, since `GITHUB_TOKEN` isn't set during deploys, this means that contributors are never fetched during Now deployments.

This PR allows tokenless fetching of contributor information during Now deployments; in the future, we may create and manage a token that we can install via [secrets](https://zeit.co/docs/v2/build-step#using-environment-variables-and-secrets).