### PR TITLE
Use gatsby-plugin-alias-imports to resolve React

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = {
   siteMetadata: {
     title: 'Doctocat',
@@ -13,5 +15,15 @@ module.exports = {
       },
     },
   ],
-  plugins: ['gatsby-plugin-sass'],
+  plugins: [
+    'gatsby-plugin-sass',
+    {
+      resolve: `gatsby-plugin-alias-imports`,
+      options: {
+        alias: {
+          react: path.resolve(__dirname, 'node_modules', 'react')
+        }
+      }
+    }
+  ],
 }

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -21,7 +21,7 @@ module.exports = {
       resolve: `gatsby-plugin-alias-imports`,
       options: {
         alias: {
-          react: path.resolve(__dirname, 'node_modules', 'react')
+          react: path.resolve(__dirname, '..', 'node_modules', 'react')
         }
       }
     }

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "@primer/css": "^12.4.1",
     "@primer/gatsby-theme-doctocat": "*",
     "gatsby": "^2.13.52",
+    "gatsby-plugin-alias-imports": "^1.0.5",
     "gatsby-plugin-sass": "^2.1.0",
     "node-sass": "^4.12.0",
     "react": "^16.8.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "develop": "gatsby develop -H 0.0.0.0",
     "build": "gatsby build --prefix-paths",
-    "now-build": "npm run build"
+    "now-build": "yarn build"
   },
   "dependencies": {
     "@primer/components": "^16.1.0",


### PR DESCRIPTION
I started running into the same issue that I was with the microsites; the fix is to tell Gatsby how to resolve React.