### PR TITLE
Remove `overflow: hidden` from live code container

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/src/components/live-code.js
+++ b/theme/src/components/live-code.js
@@ -42,7 +42,6 @@ function LiveCode({code, language, noinline}) {
       as={Flex}
       flexDirection="column"
       mb={3}
-      css={{overflow: 'hidden'}}
     >
       <LiveProvider
         scope={scope}

--- a/theme/src/components/live-code.js
+++ b/theme/src/components/live-code.js
@@ -60,6 +60,8 @@ function LiveCode({code, language, noinline}) {
             style={{
               fontFamily: theme.fonts.mono,
               fontSize: '85%',
+              borderBottomLeftRadius: '6px',
+              borderBottomRightRadius: '6px',
             }}
           />
           <Absolute top={0} right={0} p={2}>

--- a/theme/src/components/live-code.js
+++ b/theme/src/components/live-code.js
@@ -60,8 +60,8 @@ function LiveCode({code, language, noinline}) {
             style={{
               fontFamily: theme.fonts.mono,
               fontSize: '85%',
-              borderBottomLeftRadius: '6px',
-              borderBottomRightRadius: '6px',
+              borderBottomLeftRadius: theme.radii[2],
+              borderBottomRightRadius: theme.radii[2],
             }}
           />
           <Absolute top={0} right={0} p={2}>


### PR DESCRIPTION
Hiding the overflow in the live code containers breaks some of the demos that have elements that spill out of the container; see https://primer.style/components/Dropdown for an example.
