### PR TITLE
Update Octicons

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -22,7 +22,7 @@
     "@mdx-js/mdx": "^1.0.21",
     "@mdx-js/react": "^1.0.21",
     "@primer/components": "^16.1.0",
-    "@primer/styled-octicons": "^0.0.0-df8e278",
+    "@primer/styled-octicons": "^0.0.0-0ccdd71",
     "@styled-system/theme-get": "^5.0.12",
     "@testing-library/jest-dom": "^4.1.0",
     "@testing-library/react": "^9.1.3",

--- a/theme/package.json
+++ b/theme/package.json
@@ -22,7 +22,7 @@
     "@mdx-js/mdx": "^1.0.21",
     "@mdx-js/react": "^1.0.21",
     "@primer/components": "^16.1.0",
-    "@primer/octicons-react": "^9.1.1",
+    "@primer/styled-octicons": "^0.0.0-df8e278",
     "@styled-system/theme-get": "^5.0.12",
     "@testing-library/jest-dom": "^4.1.0",
     "@testing-library/react": "^9.1.3",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/src/components/clipboard-copy.js
+++ b/theme/src/components/clipboard-copy.js
@@ -1,5 +1,5 @@
-import {Button, StyledOcticon} from '@primer/components'
-import {Check, Clippy} from '@primer/octicons-react'
+import {Button} from '@primer/components'
+import {CheckIcon, ClippyIcon} from '@primer/styled-octicons'
 import copy from 'copy-to-clipboard'
 import React from 'react'
 
@@ -22,10 +22,7 @@ function ClipboardCopy({value}) {
         setCopied(true)
       }}
     >
-      <StyledOcticon
-        icon={copied ? Check : Clippy}
-        color={copied ? 'green.5' : 'gray.7'}
-      />
+      {copied ? <CheckIcon color="green.5" /> : <ClippyIcon color="gray.7" />}
     </Button>
   )
 }

--- a/theme/src/components/do-dont.js
+++ b/theme/src/components/do-dont.js
@@ -1,5 +1,5 @@
-import {CircleOcticon, Flex, Text, Grid} from '@primer/components'
-import {Check, X} from '@primer/octicons-react'
+import {Flex, Grid, Text} from '@primer/components'
+import {CheckIcon, XIcon} from '@primer/styled-octicons'
 import React from 'react'
 import Caption from './caption'
 
@@ -20,26 +20,21 @@ DoDontContainer.defaultProps = {
 }
 
 export function Do(props) {
-  return <DoDontBase {...props} text="Do" icon={Check} iconBg="green.5" />
+  return <DoDontBase {...props} text="Do" icon={CheckIcon} iconBg="green.5" />
 }
 
 export function Dont(props) {
-  return <DoDontBase {...props} text="Don't" icon={X} iconBg="red.5" />
+  return <DoDontBase {...props} text="Don't" icon={XIcon} iconBg="red.5" />
 }
 
-function DoDontBase({src, alt, children, text, icon, iconBg}) {
+function DoDontBase({src, alt, children, text, icon: Icon, iconBg}) {
   return (
     <Flex flexDirection="column">
       <Flex alignSelf="start" flexDirection="row" alignItems="center" mb="2">
-        <CircleOcticon
-          icon={icon}
-          size={16}
-          bg={iconBg}
-          color="white"
-          mr="2"
-          p="1"
-        />
-        <Text fontWeight="bold" color="gray.9" ml="1">
+        <Flex bg={iconBg} color="white" p={1} style={{borderRadius: '50%'}}>
+          <Icon verticalAlign="middle" size={12} />
+        </Flex>
+        <Text fontWeight="bold" color="gray.9" ml={2}>
           {text}
         </Text>
       </Flex>
@@ -50,5 +45,5 @@ function DoDontBase({src, alt, children, text, icon, iconBg}) {
 }
 
 DoDontBase.defaultProps = {
-  alt: "",
+  alt: '',
 }

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -1,20 +1,20 @@
-import {Box, Flex, Link, Sticky, StyledOcticon} from '@primer/components'
+import {Box, Flex, Link, Sticky} from '@primer/components'
 import {
-  ChevronRight,
-  MarkGithub,
-  ThreeBars,
-  Search as SearchIcon,
-} from '@primer/octicons-react'
+  ChevronRightIcon,
+  MarkGithubIcon,
+  SearchIcon,
+  ThreeBarsIcon,
+} from '@primer/styled-octicons'
 import {Link as GatsbyLink} from 'gatsby'
 import React from 'react'
 import {ThemeContext} from 'styled-components'
 import primerNavItems from '../primer-nav.yml'
 import useSiteMetadata from '../use-site-metadata'
 import DarkButton from './dark-button'
+import MobileSearch from './mobile-search'
 import NavDrawer, {useNavDrawerState} from './nav-drawer'
 import NavDropdown, {NavDropdownItem} from './nav-dropdown'
 import Search from './search'
-import MobileSearch from './mobile-search'
 
 export const HEADER_HEIGHT = 66
 
@@ -41,7 +41,7 @@ function Header({isSearchEnabled}) {
             mr={3}
             lineHeight="condensedUltra"
           >
-            <StyledOcticon icon={MarkGithub} size="medium" />
+            <MarkGithubIcon size="medium" />
           </Link>
           <Link
             display={[
@@ -61,7 +61,7 @@ function Header({isSearchEnabled}) {
           {siteMetadata.shortName ? (
             <>
               <Box display={['none', null, null, 'inline-block']} mx={2}>
-                <StyledOcticon icon={ChevronRight} color="blue.4" />
+                <ChevronRightIcon color="blue.4" />
               </Box>
               <Link as={GatsbyLink} to="/" color="blue.4" fontFamily="mono">
                 {siteMetadata.shortName}
@@ -87,7 +87,7 @@ function Header({isSearchEnabled}) {
                   aria-expanded={isMobileSearchOpen}
                   onClick={() => setIsMobileSearchOpen(true)}
                 >
-                  <StyledOcticon icon={SearchIcon} />
+                  <SearchIcon />
                 </DarkButton>
                 <MobileSearch
                   isOpen={isMobileSearchOpen}
@@ -101,7 +101,7 @@ function Header({isSearchEnabled}) {
               onClick={() => setIsNavDrawerOpen(true)}
               ml={3}
             >
-              <StyledOcticon icon={ThreeBars} />
+              <ThreeBarsIcon />
             </DarkButton>
             <NavDrawer
               isOpen={isNavDrawerOpen}
@@ -126,7 +126,7 @@ function PrimerNavItems({items}) {
           return (
             <Box ml={4} key={index}>
               <NavDropdown title={item.title}>
-                {item.children.map(child => (
+                {item.children.map((child) => (
                   <NavDropdownItem key={child.title} href={child.url}>
                     {child.title}
                   </NavDropdownItem>

--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -1,5 +1,5 @@
-import {Heading, Link, StyledOcticon} from '@primer/components'
-import {Link as LinkIcon} from '@primer/octicons-react'
+import {Heading, Link} from '@primer/components'
+import {LinkIcon} from '@primer/styled-octicons'
 import themeGet from '@styled-system/theme-get'
 import GithubSlugger from 'github-slugger'
 import React from 'react'
@@ -36,11 +36,7 @@ function MarkdownHeading({children, ...props}) {
         color="gray.8"
         aria-label={`${text} permalink`}
       >
-        <StyledOcticon
-          className="octicon-link"
-          icon={LinkIcon}
-          verticalAlign="middle"
-        />
+        <LinkIcon className="octicon-link" verticalAlign="middle" />
       </Link>
       {children}
     </StyledHeading>
@@ -76,9 +72,9 @@ const StyledH6 = styled(StyledHeading).attrs({as: 'h6'})`
   color: ${themeGet('colors.gray.5')};
 `
 
-export const H1 = props => <MarkdownHeading as={StyledH1} {...props} />
-export const H2 = props => <MarkdownHeading as={StyledH2} {...props} />
-export const H3 = props => <MarkdownHeading as={StyledH3} {...props} />
-export const H4 = props => <MarkdownHeading as={StyledH4} {...props} />
-export const H5 = props => <MarkdownHeading as={StyledH5} {...props} />
-export const H6 = props => <MarkdownHeading as={StyledH6} {...props} />
+export const H1 = (props) => <MarkdownHeading as={StyledH1} {...props} />
+export const H2 = (props) => <MarkdownHeading as={StyledH2} {...props} />
+export const H3 = (props) => <MarkdownHeading as={StyledH3} {...props} />
+export const H4 = (props) => <MarkdownHeading as={StyledH4} {...props} />
+export const H5 = (props) => <MarkdownHeading as={StyledH5} {...props} />
+export const H6 = (props) => <MarkdownHeading as={StyledH6} {...props} />

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,15 +1,14 @@
 import {
   BorderBox,
   Box,
+  Details,
   Flex,
   Grid,
   Heading,
   Position,
   Text,
-  Details,
-  StyledOcticon,
 } from '@primer/components'
-import {ChevronDown, ChevronRight} from '@primer/octicons-react'
+import {ChevronDownIcon, ChevronRightIcon} from '@primer/styled-octicons'
 import React from 'react'
 import Head from './head'
 import Header, {HEADER_HEIGHT} from './header'
@@ -88,10 +87,11 @@ function Layout({children, pageContext}) {
                   {({open}) => (
                     <>
                       <Text as="summary" fontWeight="bold">
-                        <StyledOcticon
-                          icon={open ? ChevronDown : ChevronRight}
-                          mr={2}
-                        />
+                        {open ? (
+                          <ChevronDownIcon mr={2} />
+                        ) : (
+                          <ChevronRightIcon mr={2} />
+                        )}
                         Table of contents
                       </Text>
                       <Box pt={1}>
@@ -108,7 +108,7 @@ function Layout({children, pageContext}) {
             <PageFooter
               editUrl={pageContext.editUrl}
               contributors={pageContext.contributors.concat(
-                additionalContributors.map(login => ({login})),
+                additionalContributors.map((login) => ({login})),
               )}
             />
           </Box>

--- a/theme/src/components/mobile-search.js
+++ b/theme/src/components/mobile-search.js
@@ -1,5 +1,5 @@
-import {Absolute, Fixed, Flex, StyledOcticon} from '@primer/components'
-import {X} from '@primer/octicons-react'
+import {Absolute, Fixed, Flex} from '@primer/components'
+import {XIcon} from '@primer/styled-octicons'
 import Downshift from 'downshift'
 import {AnimatePresence, motion} from 'framer-motion'
 import {navigate} from 'gatsby'
@@ -55,15 +55,15 @@ function MobileSearch({isOpen, onDismiss}) {
             />
             <Downshift
               inputValue={query}
-              onInputValueChange={inputValue => setQuery(inputValue)}
+              onInputValueChange={(inputValue) => setQuery(inputValue)}
               selectedItem={null}
-              onSelect={item => {
+              onSelect={(item) => {
                 if (item) {
                   navigate(item.path)
                   handleDismiss()
                 }
               }}
-              itemToString={item => (item ? item.title : '')}
+              itemToString={(item) => (item ? item.title : '')}
               stateReducer={stateReducer}
             >
               {({
@@ -100,7 +100,7 @@ function MobileSearch({isOpen, onDismiss}) {
                       aria-label="Cancel"
                       onClick={handleDismiss}
                     >
-                      <StyledOcticon icon={X} />
+                      <XIcon />
                     </DarkButton>
                   </Flex>
                   {isMenuOpen ? (

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -1,5 +1,5 @@
-import {BorderBox, Flex, Link, StyledOcticon, Text} from '@primer/components'
-import {ChevronDown, ChevronUp, X} from '@primer/octicons-react'
+import {BorderBox, Flex, Link, Text} from '@primer/components'
+import {ChevronDownIcon, ChevronUpIcon, XIcon} from '@primer/styled-octicons'
 import {Link as GatsbyLink} from 'gatsby'
 import debounce from 'lodash.debounce'
 import React from 'react'
@@ -74,7 +74,7 @@ function NavDrawer({isOpen, onDismiss}) {
                 Primer
               </Link>
               <DarkButton aria-label="Close" onClick={onDismiss}>
-                <StyledOcticon icon={X} />
+                <XIcon />
               </DarkButton>
             </Flex>
           </BorderBox>
@@ -126,11 +126,11 @@ function PrimerNavItems({items}) {
                 <summary onClick={toggle} style={{cursor: 'pointer'}}>
                   <Flex alignItems="center" justifyContent="space-between">
                     <Text>{item.title}</Text>
-                    <StyledOcticon icon={open ? ChevronUp : ChevronDown} />
+                    {open ? <ChevronUpIcon /> : <ChevronDownIcon />}
                   </Flex>
                 </summary>
                 <Flex flexDirection="column" mt={2}>
-                  {item.children.map(child => (
+                  {item.children.map((child) => (
                     <Link
                       key={child.title}
                       href={child.url}

--- a/theme/src/components/nav-dropdown.js
+++ b/theme/src/components/nav-dropdown.js
@@ -1,11 +1,5 @@
-import {
-  Absolute,
-  BorderBox,
-  StyledOcticon,
-  Text,
-  themeGet,
-} from '@primer/components'
-import {ChevronDown} from '@primer/octicons-react'
+import {Absolute, BorderBox, Text, themeGet} from '@primer/components'
+import {ChevronDownIcon} from '@primer/styled-octicons'
 import React from 'react'
 import styled from 'styled-components'
 import Details from './details'
@@ -17,7 +11,7 @@ function NavDropdown({title, children}) {
         <>
           <summary style={{cursor: 'pointer'}} onClick={toggle}>
             <Text>{title}</Text>
-            <StyledOcticon icon={ChevronDown} ml={1} />
+            <ChevronDownIcon ml={1} />
           </summary>
           <Absolute>
             <BorderBox

--- a/theme/src/components/nav-items.js
+++ b/theme/src/components/nav-items.js
@@ -1,11 +1,5 @@
-import {
-  BorderBox,
-  Flex,
-  Link,
-  StyledOcticon,
-  themeGet,
-} from '@primer/components'
-import {LinkExternal} from '@primer/octicons-react'
+import {BorderBox, Flex, Link, themeGet} from '@primer/components'
+import {LinkExternalIcon} from '@primer/styled-octicons'
 import {Link as GatsbyLink} from 'gatsby'
 import preval from 'preval.macro'
 import React from 'react'
@@ -33,7 +27,7 @@ const NavLink = styled(Link)`
 function NavItems({items}) {
   return (
     <>
-      {items.map(item => (
+      {items.map((item) => (
         <BorderBox
           key={item.title}
           border={0}
@@ -53,7 +47,7 @@ function NavItems({items}) {
             </NavLink>
             {item.children ? (
               <Flex flexDirection="column" mt={2}>
-                {item.children.map(child => (
+                {item.children.map((child) => (
                   <NavLink
                     key={child.title}
                     as={GatsbyLink}
@@ -77,7 +71,7 @@ function NavItems({items}) {
           <Link href={repositoryUrl} color="inherit">
             <Flex justifyContent="space-between" alignItems="center">
               GitHub
-              <StyledOcticon icon={LinkExternal} color="gray.7"></StyledOcticon>
+              <LinkExternalIcon color="gray.7" />
             </Flex>
           </Link>
         </BorderBox>

--- a/theme/src/components/page-footer.js
+++ b/theme/src/components/page-footer.js
@@ -1,5 +1,5 @@
-import {BorderBox, Grid, Link, StyledOcticon} from '@primer/components'
-import {Pencil} from '@primer/octicons-react'
+import {BorderBox, Grid, Link} from '@primer/components'
+import {PencilIcon} from '@primer/styled-octicons'
 import React from 'react'
 import Contributors from './contributors'
 
@@ -9,7 +9,7 @@ function PageFooter({editUrl, contributors}) {
       <Grid gridGap={4}>
         {editUrl ? (
           <Link href={editUrl}>
-            <StyledOcticon icon={Pencil} mr={2} />
+            <PencilIcon mr={2} />
             Edit this page on GitHub
           </Link>
         ) : null}

--- a/theme/src/components/source-link.js
+++ b/theme/src/components/source-link.js
@@ -1,11 +1,11 @@
-import {Link, StyledOcticon} from '@primer/components'
-import {FileCode} from '@primer/octicons-react'
+import {Link} from '@primer/components'
+import {CodeIcon} from '@primer/styled-octicons'
 import React from 'react'
 
 function SourceLink({href}) {
   return (
     <Link href={href} lineHeight="condensedUltra" fontSize={1}>
-      <StyledOcticon icon={FileCode} mr={2} />
+      <CodeIcon mr={2} />
       View source
     </Link>
   )

--- a/theme/src/components/status-label.js
+++ b/theme/src/components/status-label.js
@@ -1,5 +1,5 @@
-import {BorderBox, Flex, StyledOcticon, Text} from '@primer/components'
-import {PrimitiveDot} from '@primer/octicons-react'
+import {BorderBox, Flex, Text} from '@primer/components'
+import {DotFillIcon} from '@primer/styled-octicons'
 import React from 'react'
 
 const STATUS_COLORS = {
@@ -18,11 +18,7 @@ function StatusLabel({status}) {
   return (
     <BorderBox display="inline-block" px={2} py={1}>
       <Flex alignItems="center">
-        <StyledOcticon
-          icon={PrimitiveDot}
-          color={getStatusColor(status)}
-          mr={2}
-        />
+        <DotFillIcon color={getStatusColor(status)} mr={2} />
         <Text fontSize={1}>{status}</Text>
       </Flex>
     </BorderBox>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,10 +1145,10 @@
   dependencies:
     object-assign "^4.1.1"
 
-"@primer/styled-octicons@^0.0.0-df8e278":
-  version "0.0.0-df8e278"
-  resolved "https://registry.yarnpkg.com/@primer/styled-octicons/-/styled-octicons-0.0.0-df8e278.tgz#dfa55f2bc78f3e7ebd4ee36ee20b5162d3d74100"
-  integrity sha512-MDI8P1Skeei2JsMkOu251ZfRUgWSaWAUgnEaHA9A5sJnLP9BA/jQ3B57I55s0hx0U4r+RBGOPctxv/T5UY9WuA==
+"@primer/styled-octicons@^0.0.0-0ccdd71":
+  version "0.0.0-0ccdd71"
+  resolved "https://registry.yarnpkg.com/@primer/styled-octicons/-/styled-octicons-0.0.0-0ccdd71.tgz#ceea91793895fc6234eb24f57a0e349a085db520"
+  integrity sha512-TKjEz4auK9EfxGU3X2qqa89torZUA9r7/Rh3rEI2B8acoGf29oCJvqlTyZYA/tO3tzQrPPb25ViyJ5FNqrhzCQ==
   dependencies:
     "@styled-system/css" "^5.1.5"
     "@styled-system/prop-types" "^5.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,13 +1131,6 @@
   dependencies:
     "@primer/octicons" "^9.1.1"
 
-"@primer/octicons-react@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-9.1.1.tgz#bee3d091c6ecc179c5e46d4716929b987b07baf7"
-  integrity sha512-+ZgALoxUOYUeEnqqN6ZqSfRP6LDRgfmErhY4ZIuGlw5Ocjj7AI87J68dD/wYqWl4IW7xE6rmLvpC3kU3iGmAfQ==
-  dependencies:
-    prop-types "^15.6.1"
-
 "@primer/octicons-react@^9.2.0":
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-9.2.0.tgz#76446c36346fef67cbf91c78bd329c8f860c35d5"
@@ -1151,6 +1144,17 @@
   integrity sha512-7EGM0+Kx39bIgaYr9bTCzFvBCxm+fqh/YJIoSns8zfCwss32ZJ2GDP3024UH709VQtM5cKFU4JcIYPHyGdSfIg==
   dependencies:
     object-assign "^4.1.1"
+
+"@primer/styled-octicons@^0.0.0-df8e278":
+  version "0.0.0-df8e278"
+  resolved "https://registry.yarnpkg.com/@primer/styled-octicons/-/styled-octicons-0.0.0-df8e278.tgz#dfa55f2bc78f3e7ebd4ee36ee20b5162d3d74100"
+  integrity sha512-MDI8P1Skeei2JsMkOu251ZfRUgWSaWAUgnEaHA9A5sJnLP9BA/jQ3B57I55s0hx0U4r+RBGOPctxv/T5UY9WuA==
+  dependencies:
+    "@styled-system/css" "^5.1.5"
+    "@styled-system/prop-types" "^5.1.5"
+    "@types/styled-system" "^5.1.9"
+    "@types/styled-system__css" "^5.0.8"
+    styled-system "^5.1.5"
 
 "@reach/component-component@^0.3.0":
   version "0.3.0"
@@ -1288,6 +1292,13 @@
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@styled-system/prop-types/-/prop-types-5.1.2.tgz#252898644aa277fcdb1bb916c3b354c78b78155a"
   integrity sha512-q2hnuZrOjZdCRYvSoMF5VIDRfpqPHDSgqajoMH0iy7BszPAkZZcIC7L4PzJTIcGSBrB9OJTBitWo9s7N60tgtA==
+  dependencies:
+    prop-types "^15.7.2"
+
+"@styled-system/prop-types@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@styled-system/prop-types/-/prop-types-5.1.5.tgz#f813b78c583f9a3a9693d5eb185c2fd3dd0448a8"
+  integrity sha512-D/0d0ltp8QGhwrRifivQeIdoKkQDpFIGi98DXdpRXOaJStYXLx6aBSfS/YYIijbF1nZs1hWlAgXxYvDhCxHLSA==
   dependencies:
     prop-types "^15.7.2"
 
@@ -1591,6 +1602,20 @@
   integrity sha512-Byh33qthYnI6+qS0TRr4vqd+N/ax6ic1NFE6ZA16xuVr/EvYvSB8+diEP1lTSE7sP/MTdQpl+KaONREnyalDUA==
   dependencies:
     csstype "^2.6.4"
+
+"@types/styled-system@^5.1.9":
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.9.tgz#8baac8f6eca9e0bd5768c175ca5ce1f2d6f61ade"
+  integrity sha512-QlWv6tmQV8dqk8s+LSLb9QAtmuQEnfv4f8lKKZkMgDqRFVmxJDBwEw0u4zhpxp56u0hdR+TCIk9dGfOw3TkCoQ==
+  dependencies:
+    csstype "^2.6.9"
+
+"@types/styled-system__css@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@types/styled-system__css/-/styled-system__css-5.0.8.tgz#3886fc89e003aadda858349a5cf324fe54b09980"
+  integrity sha512-skv+daDje8vWQ8wnqVV0GCzgWVKx4gI9lJpAxWE77s52Ne6k/SCPP8HGE4BFbWDvK+qi5O3p89BGWVOQ1VHjMg==
+  dependencies:
+    csstype "^2.6.6"
 
 "@types/testing-library__dom@*", "@types/testing-library__dom@^6.0.0":
   version "6.0.1"
@@ -4081,6 +4106,11 @@ csstype@^2.2.0, csstype@^2.6.4:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
+
+csstype@^2.6.6, csstype@^2.6.9:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -12883,7 +12913,7 @@ styled-system@5.1.2, styled-system@^5.0.18:
     "@styled-system/variant" "^5.1.2"
     object-assign "^4.1.1"
 
-styled-system@^5.1.4:
+styled-system@^5.1.4, styled-system@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-5.1.5.tgz#e362d73e1dbb5641a2fd749a6eba1263dc85075e"
   integrity sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==


### PR DESCRIPTION
This PR updates Dotocat to use the new Octicons and replaces all usages of `StyledOcticon` in the codebase with icon components from [`@primer/styled-octicons`](https://github.com/primer/octicons/pull/417). 