### PR TITLE
Rename Primer Components to Primer React

### DIFF
--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -14,7 +14,7 @@
   children:
     - title: Primer CSS
       url: https://primer.style/css
-    - title: Primer Components
+    - title: Primer React
       url: https://primer.style/components
 - title: About
   url: https://primer.style/team


### PR DESCRIPTION
This PR changes the Primer Components naming in the top nav to be Primer React :) 