### PR TITLE
fix: ERROR #98123 when `gatsby develop` with shadowed hero.js

### DIFF
--- a/docs/content/usage/customization.mdx
+++ b/docs/content/usage/customization.mdx
@@ -123,6 +123,7 @@ To use a custom hero component, [shadow](https://www.gatsbyjs.org/blog/2019-04-2
 ```jsx
 // src/@primer/gatsby-theme-doctocat/components/hero.js
 import {Box} from '@primer/components'
+import React from 'react';
 
 export default function Hero() {
   return (


### PR DESCRIPTION
When running `gatsby develop`, the CLI was returning an error. 

```
 ERROR #98123  WEBPACK

Generating development JavaScript bundle failed


~/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
  6:5  error  'React' must be in scope when using JSX  react/react-in-jsx-scope

✖ 1 problem (1 error, 0 warnings)


File: src/@primer/gatsby-theme-doctocat/components/hero.js

failed Re-building development bundle - 1.190s
```

Adding this line fixes the error.