### PR TITLE
Table of contents updates

### DIFF
--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -17,7 +17,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
           frontmatter {
             title
           }
-          tableOfContents
+          tableOfContents(maxDepth: 3)
           parent {
             ... on File {
               relativeDirectory

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -9,7 +9,7 @@ import {
   StyledOcticon,
   Text,
 } from '@primer/components'
-import {ChevronDownIcon, ChevronRightIcon} from '@primer/octicons-react'
+import {ChevronDownIcon, ChevronUpIcon} from '@primer/octicons-react'
 import React from 'react'
 import Head from './head'
 import Header, {HEADER_HEIGHT} from './header'
@@ -48,7 +48,7 @@ function Layout({children, pageContext}) {
           gridColumnGap={[null, null, 6, 7]}
           gridRowGap={3}
           mx="auto"
-          p={[5, 6, null, 7]}
+          p={[4, 5, 6, 7]}
           css={{alignItems: 'start', alignSelf: 'start'}}
         >
           <BorderBox
@@ -66,7 +66,6 @@ function Layout({children, pageContext}) {
               css={{gridArea: 'table-of-contents', overflow: 'auto'}}
               position="sticky"
               top={HEADER_HEIGHT + 24}
-              mt="6px"
               maxHeight={`calc(100vh - ${HEADER_HEIGHT}px - 24px)`}
             >
               <Text display="inline-block" fontWeight="bold" mb={1}>
@@ -84,19 +83,44 @@ function Layout({children, pageContext}) {
               </Flex>
             ) : null}
             {pageContext.tableOfContents.items ? (
-              <Box display={['block', null, 'none']} mb={3}>
+              <Box
+                display={['block', null, 'none']}
+                mb={3}
+                bg="gray.1"
+                sx={{borderRadius: 2}}
+              >
                 <Details>
                   {({open}) => (
                     <>
-                      <Text as="summary" fontWeight="bold">
-                        {open ? (
-                          <StyledOcticon icon={ChevronDownIcon} mr={2} />
-                        ) : (
-                          <StyledOcticon icon={ChevronRightIcon} mr={2} />
-                        )}
-                        Table of contents
-                      </Text>
-                      <Box pt={1}>
+                      <Box as="summary" p={3} sx={{cursor: 'pointer'}}>
+                        <Flex
+                          flexDirection="row"
+                          justifyContent="space-between"
+                          alignItems="center"
+                        >
+                          <Text fontWeight="bold">Table of contents</Text>
+                          {open ? (
+                            <StyledOcticon
+                              icon={ChevronUpIcon}
+                              mr={2}
+                              color="gray.7"
+                            />
+                          ) : (
+                            <StyledOcticon
+                              icon={ChevronDownIcon}
+                              mr={2}
+                              color="gray.7"
+                            />
+                          )}
+                        </Flex>
+                      </Box>
+                      <Box
+                        p={3}
+                        sx={{
+                          borderTop: '1px solid',
+                          borderColor: 'border.gray',
+                        }}
+                      >
                         <TableOfContents
                           items={pageContext.tableOfContents.items}
                         />

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -39,7 +39,7 @@ function Layout({children, pageContext}) {
         <Grid
           id="skip-nav"
           maxWidth="100%"
-          gridTemplateColumns={['100%', null, 'minmax(0, 65ch) 220px']}
+          gridTemplateColumns={['100%', null, 'minmax(0, 960px) 220px']}
           gridTemplateAreas={[
             '"heading" "content"',
             null,

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -98,13 +98,13 @@ function Layout({children, pageContext}) {
                             <StyledOcticon
                               icon={ChevronUpIcon}
                               mr={2}
-                              color="gray.7"
+                              color="gray.6"
                             />
                           ) : (
                             <StyledOcticon
                               icon={ChevronDownIcon}
                               mr={2}
-                              color="gray.7"
+                              color="gray.6"
                             />
                           )}
                         </Flex>

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -83,12 +83,7 @@ function Layout({children, pageContext}) {
               </Flex>
             ) : null}
             {pageContext.tableOfContents.items ? (
-              <Box
-                display={['block', null, 'none']}
-                mb={3}
-                bg="gray.1"
-                sx={{borderRadius: 2}}
-              >
+              <BorderBox display={['block', null, 'none']} mb={3} bg="gray.1">
                 <Details>
                   {({open}) => (
                     <>
@@ -128,7 +123,7 @@ function Layout({children, pageContext}) {
                     </>
                   )}
                 </Details>
-              </Box>
+              </BorderBox>
             ) : null}
             {children}
             <PageFooter

--- a/theme/src/components/table-of-contents.js
+++ b/theme/src/components/table-of-contents.js
@@ -6,15 +6,17 @@ function TableOfContents({items, depth}) {
     <Box as="ul" m={0} p={0} css={{listStyle: 'none'}}>
       {items.map((item) => (
         <Box as="li" key={item.url} pl={depth > 0 ? 3 : 0}>
-          <Link
-            display="inline-block"
-            py={1}
-            href={item.url}
-            fontSize={1}
-            color="gray.6"
-          >
-            {item.title}
-          </Link>
+          {item.title ? (
+            <Link
+              display="inline-block"
+              py={1}
+              href={item.url}
+              fontSize={1}
+              color="gray.6"
+            >
+              {item.title}
+            </Link>
+          ) : null}
           {item.items ? (
             <TableOfContents items={item.items} depth={depth + 1} />
           ) : null}

--- a/theme/src/components/table-of-contents.js
+++ b/theme/src/components/table-of-contents.js
@@ -4,9 +4,15 @@ import React from 'react'
 function TableOfContents({items, depth}) {
   return (
     <Box as="ul" m={0} p={0} css={{listStyle: 'none'}}>
-      {items.map(item => (
+      {items.map((item) => (
         <Box as="li" key={item.url} pl={depth > 0 ? 3 : 0}>
-          <Link display="inline-block" py={1} href={item.url} color="gray.6">
+          <Link
+            display="inline-block"
+            py={1}
+            href={item.url}
+            fontSize={1}
+            color="gray.6"
+          >
             {item.title}
           </Link>
           {item.items ? (

--- a/theme/src/components/table-of-contents.js
+++ b/theme/src/components/table-of-contents.js
@@ -11,7 +11,7 @@ function TableOfContents({items, depth}) {
               display="inline-block"
               py={1}
               href={item.url}
-              fontSize={1}
+              fontSize={[2, null, 1]}
               color="gray.6"
             >
               {item.title}


### PR DESCRIPTION
This PR addresses the table of contents feedback in https://github.com/primer/doctocat/issues/137. Here's what changed:

👉   [Preview](https://doctocat-git-toc-updates.primer.vercel.app/doctocat/)

- [x] Reduced the font size of the table of contents items from 16px to 14px

| Before | After |
| --- | --- |
|  ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2FyOClhhgVYR.png?alt=media&token=f537ac7c-1702-459c-8dae-474da9ecafef) | ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2FgzoRT1KKGv.png?alt=media&token=899d53ec-afa6-4476-a35a-a677b41cde3d)|

- [x] Increased the max width of main content area to `960px`  

| Before | After |
| --- | --- |
| ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2Fcx3X6099F-.png?alt=media&token=02642c90-5c7c-4ff1-a7e7-7cc2101e7d0b) | ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2Fx4BNxSDKmj.png?alt=media&token=894805fd-3bb9-4da6-86f9-c99e9adbc8fc) |

- [x] Limited the depth of the table of contents to `h3`

| Before | After |
| --- | --- |
| ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2FHre9mzam8-.png?alt=media&token=f86f156f-11a3-4acf-9102-cb901a745d5c) | ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2FnK1j6XB07m.png?alt=media&token=f7a86fe8-ede3-449f-b63d-0d9772c489c7) |

- [x] Collapsed empty table of contents items

| Before | After |
| --- | --- |
| ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2FT7stWw57Kj.png?alt=media&token=be45e364-8a74-4fde-9ff7-f80c5cbd4a10) | ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2FJxcGyi7Djk.png?alt=media&token=b6b4e4c1-c9f0-4bc8-8003-b1acf4c5efb2) |

- [x] Updated mobile table of contents based on @ashygee's designs (I kept the font size at 16px on mobile because 14px seemed too small and hard to tap on mobile screens)

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4608155/91219007-ce7a6280-e6ce-11ea-9372-0abf6057f6eb.png) ![image](https://user-images.githubusercontent.com/4608155/91219046-dd611500-e6ce-11ea-8032-80a994239707.png)  | ![image](https://user-images.githubusercontent.com/4608155/91218939-b4d91b00-e6ce-11ea-95d6-35dd0b253011.png) ![image](https://user-images.githubusercontent.com/4608155/91218952-bacefc00-e6ce-11ea-8ad1-765cbe54ac53.png) |

Closes https://github.com/primer/doctocat/issues/137