### PR TITLE
Fix responsive navigation drawer on tall screens

### DIFF
--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -52,7 +52,7 @@ function NavDrawer({isOpen, onDismiss}) {
         bg="gray.9"
         style={{overflow: 'auto', WebkitOverflowScrolling: 'touch'}}
       >
-        <Flex flexDirection="column" flex="1 0 auto" color="blue.2" bg="gray.9">
+        <Flex flexDirection="column" flex="0 0 auto" color="blue.2" bg="gray.9">
           <BorderBox
             borderWidth={0}
             borderRadius={0}


### PR DESCRIPTION
## Problem

The dark "Primer" section of the responsive navigation drawer stretches on when the viewport is taller than the content.

## Solution

Applying `flex: 0 0 auto` to that section fixed the issue.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4608155/91345246-e9fb7100-e793-11ea-9e02-9ff096679def.png) | ![image](https://user-images.githubusercontent.com/4608155/91756044-f65f3f80-eb80-11ea-9771-f2098a502c54.png) |

Closes #168 
