### PR TITLE
Fix hot module reloading

### DIFF
--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -16,6 +16,9 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
           fileAbsolutePath
           frontmatter {
             title
+            status
+            source
+            additionalContributors
           }
           tableOfContents
           parent {
@@ -71,7 +74,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
           // for us here, and does on the first build,
           // but when HMR kicks in the frontmatter is lost.
           // The solution is to include it here explicitly.
-          // frontmatter: node.frontmatter
+          frontmatter: node.frontmatter,
         },
       })
     }),

--- a/theme/src/components/hero-layout.js
+++ b/theme/src/components/hero-layout.js
@@ -8,7 +8,11 @@ import Hero from './hero'
 import Sidebar from './sidebar'
 
 function HeroLayout({children, pageContext}) {
-  const {additionalContributors = []} = pageContext.frontmatter
+  let {additionalContributors} = pageContext.frontmatter
+
+  if (!additionalContributors) {
+    additionalContributors = []
+  }
 
   return (
     <Flex flexDirection="column" minHeight="100vh">

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -20,13 +20,17 @@ import StatusLabel from './status-label'
 import TableOfContents from './table-of-contents'
 
 function Layout({children, pageContext}) {
-  const {
+  let {
     title,
     description,
     status,
     source,
-    additionalContributors = [],
+    additionalContributors,
   } = pageContext.frontmatter
+
+  if (!additionalContributors) {
+    additionalContributors = []
+  }
 
   return (
     <Flex flexDirection="column" minHeight="100vh">


### PR DESCRIPTION
## Problem

When making changes to a `.md` or `.mdx` page in a Doctocat site, this error appears:

![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fcolebemis%2FXhhMWidajN.png?alt=media&token=13deac83-81dc-4a89-96fe-1e993a47c3a3)

This error occurs because `gatsby-plugin-mdx` should insert `frontmatter` in the page context of every page, and does on the first build, but when HMR kicks in the frontmatter is lost.

This is a known bug in gatsby-plugin-mdx: https://github.com/gatsbyjs/gatsby/issues/21837

## Possible solutions
- Solution 1: Explicitly add `frontmatter` to the page context in our local `gatsby-node.js` instead of relying on `gatsby-plugin-mdx` to handle `frontmatter` for us (This is the solution implemented in this PR)
- Solution 2: Fix `gatsby-plugin-mdx` so that it correctly sets the `frontmatter` when a page is hot reloaded.

### Solution 1 (implemented)

@BinaryMuse had previously implemented this solution in https://github.com/primer/doctocat/pull/116. However, the GraphQL query that fetched the frontmatter only requested the `title` field. This caused frontmatter fields like [`status`](https://doctocat-git-persist-scroll.primer.vercel.app/doctocat/usage/front-matter#status) and [`source`](https://doctocat-git-persist-scroll.primer.vercel.app/doctocat/usage/front-matter#source) to be lost.

In this PR, I reimplemented @BinaryMuse's solution and added `status`, `source`, `additionalContributors` fields to the frontmatter GraphQL request.

#### Downsides

- Adding defaults to destructured variables doesn't work anymore because missing fields are `null` not `undefined`. Here's how I worked around that in this PR:

```diff
- const {additionalContributors = []} = frontmatter
+ let {additionalContributors} = frontmatter
+ if (!additionalContributors) {
+   additionalContributors = []
+ }
```

- Adding extra frontmatter variables won't be added to the page context unless you explicitly add them to the request in gatsby-node.js. This is not obvious and will cause frustration in the future.


### Solution 2

I think this is the Right™️ solution, but I'm not sure how to implement it. I would have to a deep dive into the internals of `gatsby-plugin-mdx` and Gatsby itself.

Closes https://github.com/primer/doctocat/issues/146