### PR TITLE
Fix frontmatter GraphQL error

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "main": "index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Problem

In https://github.com/primer/doctocat/pull/175, I introduced a bug that caused site [builds to fail](https://vercel.com/primer/primer-components/ln2bvpaek) if their markdown files didn't have specific frontmatter variables. This occurred because I added more frontmatter variables to the GraphQL request used to create pages in order to pass them to the page context. However, if we request a frontmatter variable that doesn't exist in any markdown files in the site, the build fails.

## Solution

Instead of getting frontmatter from a GraphQL request, I used utility functions from `gatsby-plugin-mdx` to extract frontmatter variables from the raw MDX code. This is a workaround until https://github.com/gatsbyjs/gatsby/issues/21837 is fixed.
