### PR TITLE
Allow for default branches other than 'master' 

### DIFF
--- a/docs/content/usage/customization.mdx
+++ b/docs/content/usage/customization.mdx
@@ -77,7 +77,7 @@ module.exports = {
 }
 ```
 
-### Default Branch
+### Default branch
 
 If your site uses a branch other than `master` for your default branch, you'll also need to let Doctocat know via the `defaultBranch` option in `gatsby-config.js`:
 

--- a/docs/content/usage/customization.mdx
+++ b/docs/content/usage/customization.mdx
@@ -59,6 +59,8 @@ To enable these features, you'll need to specify your site's [`repository`](http
 }
 ```
 
+## Subdirectories
+
 If your site is located in a subdirectory of a repository, you'll also need to provide the relative path to the root of your git respository via the `repoRootPath` option in `gatsby-config.js`:
 
 ```js
@@ -69,6 +71,24 @@ module.exports = {
       resolve: '@primer/gatsby-theme-doctocat',
       options: {
         repoRootPath: '..', // defaults to '.'
+      },
+    },
+  ],
+}
+```
+
+### Default Branch
+
+If your site uses a branch other than `master` for your default branch, you'll also need to let Doctocat know via the `defaultBranch` option in `gatsby-config.js`:
+
+```js
+// gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: '@primer/gatsby-theme-doctocat',
+      options: {
+        defaultBranch: 'main', // defaults to 'master'
       },
     },
   ],

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -52,8 +52,8 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
         rootAbsolutePath,
         node.fileAbsolutePath,
       )
-
-      const editUrl = getEditUrl(repo, fileRelativePath)
+      const defaultBranch = themeOptions.defaultBranch || 'master'
+      const editUrl = getEditUrl(repo, fileRelativePath, defaultBranch)
 
       let contributors = []
       if (process.env.GITHUB_TOKEN || process.env.NOW_GITHUB_DEPLOYMENT) {
@@ -83,8 +83,8 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
   )
 }
 
-function getEditUrl(repo, filePath) {
-  return `https://github.com/${repo.user}/${repo.project}/edit/master/${filePath}`
+function getEditUrl(repo, filePath, defaultBranch) {
+  return `https://github.com/${repo.user}/${repo.project}/edit/${defaultBranch}/${filePath}`
 }
 
 async function fetchContributors(repo, filePath, accessToken = "") {

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/gatsby-theme-doctocat",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "main": "index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR updates Doctocat to work with projects that use something other than `master` for their default branch. The only change I needed to make was with the `Edit this on GitHub` link which assumed that the default branch was `master`. We now allow passing a `defaultBranch` option to the `options` object in `gatsby-config.js`

Addresses: https://github.com/primer/components/issues/876