### PR TITLE
Modify changesets changelog format

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", {"repo": "primer/doctocat"}],
   "commit": false,
   "linked": [],
   "access": "public",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "docs"
   ],
   "dependencies": {
+    "@changesets/changelog-github": "^0.2.7",
     "@changesets/cli": "^2.10.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,6 +1049,15 @@
     "@manypkg/get-packages" "^1.0.1"
     semver "^5.4.1"
 
+"@changesets/changelog-github@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@changesets/changelog-github/-/changelog-github-0.2.7.tgz#11ad3e89276cf867fabeb09fd36774a67347ac89"
+  integrity sha512-bWK8IADPYsiSiyORNpVLbmdo7J7A4LktmzUowtIivslP03UW5f/YBDzGub7N0+BVdVmZrqvyWzAIKmpGVkEICg==
+  dependencies:
+    "@changesets/get-github-info" "^0.4.4"
+    "@changesets/types" "^3.0.0"
+    dotenv "^8.1.0"
+
 "@changesets/cli@^2.10.3":
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.10.3.tgz#4ba447434c21b66fd5ce8b31fedc915c9fcd12a0"
@@ -1114,6 +1123,14 @@
     chalk "^2.1.0"
     fs-extra "^7.0.1"
     semver "^5.4.1"
+
+"@changesets/get-github-info@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@changesets/get-github-info/-/get-github-info-0.4.4.tgz#a2911e93aa0809506cd8806f365180cf8833eb6f"
+  integrity sha512-WoVdRBQXLvJVg3jsMc0+aB8WAFzSGOG45HSo2ep46ixq5lBjM2D51MbgtSYHRGFGvYuAUu6kAfnVmoZYCZFsKQ==
+  dependencies:
+    dataloader "^1.4.0"
+    node-fetch "^2.5.0"
 
 "@changesets/get-release-plan@^2.0.1":
   version "2.0.1"
@@ -5731,7 +5748,7 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^8.2.0:
+dotenv@^8.1.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==


### PR DESCRIPTION
This PR sets the changesets changelog format to [`@changesets/changelog-github`](https://github.com/atlassian/changesets/tree/master/packages/changelog-github).  The `@changesets/changelog-github` format gives credit to contributors, unlike the default format.

| Default | @changesets/changelog-github |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/4608155/94746172-ff366300-0330-11eb-92f2-d9433e073894.png) | ![image](https://user-images.githubusercontent.com/4608155/94746220-1bd29b00-0331-11eb-9837-d95554be1d8d.png) |
