### PR TITLE
Fetch contributor data on deploy builds again

### DIFF
--- a/.changeset/curly-hats-grow.md
+++ b/.changeset/curly-hats-grow.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+Fetch contributor data on deploy builds again

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -29,8 +29,14 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
     }
   `)
 
-  if (!process.env.GITHUB_TOKEN && !process.env.NOW_GITHUB_DEPLOYMENT) {
-    console.error(`Non-deploy build and no GITHUB_TOKEN environment variable set; skipping GitHub API calls`)
+  if (
+    !process.env.GITHUB_TOKEN &&
+    !process.env.NOW_GITHUB_DEPLOYMENT &&
+    !process.env.VERCEL_GITHUB_DEPLOYMENT
+  ) {
+    console.error(
+      `Non-deploy build and no GITHUB_TOKEN environment variable set; skipping GitHub API calls`,
+    )
   }
 
   // Turn every MDX file into a page.
@@ -56,8 +62,16 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
       const editUrl = getEditUrl(repo, fileRelativePath, defaultBranch)
 
       let contributors = []
-      if (process.env.GITHUB_TOKEN || process.env.NOW_GITHUB_DEPLOYMENT) {
-        contributors = await fetchContributors(repo, fileRelativePath, process.env.GITHUB_TOKEN)
+      if (
+        process.env.GITHUB_TOKEN ||
+        process.env.NOW_GITHUB_DEPLOYMENT ||
+        process.env.VERCEL_GITHUB_DEPLOYMENT
+      ) {
+        contributors = await fetchContributors(
+          repo,
+          fileRelativePath,
+          process.env.GITHUB_TOKEN,
+        )
       }
 
       // Copied from gatsby-plugin-mdx (https://git.io/JUs3H)
@@ -87,7 +101,7 @@ function getEditUrl(repo, filePath, defaultBranch) {
   return `https://github.com/${repo.user}/${repo.project}/edit/${defaultBranch}/${filePath}`
 }
 
-async function fetchContributors(repo, filePath, accessToken = "") {
+async function fetchContributors(repo, filePath, accessToken = '') {
   const hash = `${repo.user}/${repo.project}/${filePath}`
   const cached = CONTRIBUTOR_CACHE.get(hash)
   if (cached) {
@@ -98,12 +112,12 @@ async function fetchContributors(repo, filePath, accessToken = "") {
     const req = {
       method: 'get',
       baseURL: 'https://api.github.com/',
-      url: `/repos/${repo.user}/${repo.project}/commits?path=${filePath}&per_page=100`
+      url: `/repos/${repo.user}/${repo.project}/commits?path=${filePath}&per_page=100`,
     }
 
     if (accessToken && accessToken.length) {
       req.headers = {
-        'Authorization': `token ${accessToken}`
+        Authorization: `token ${accessToken}`,
       }
     }
 


### PR DESCRIPTION
## Problem

Contributor data wasn't being shown on some Doctocat sites:

![image](https://user-images.githubusercontent.com/4608155/94833460-ffcc0980-03c3-11eb-9ecb-f1bde938d9b9.png)

Contributor data is only fetched when a `GITHUB_TOKEN` environment variable is defined or during a deploy build. We were using the `NOW_GITHUB_DEPLOYMENT` environment variable to detect deploy builds. However, Vercel recently renamed the `NOW_GITHUB_DEPLOYMENT` environment variable to `VERCEL_GITHUB_DEPLOYMENT` so we didn't detect deploy builds anymore.

## Solution

This PR adds a check for `VERCEL_GITHUB_DEPLOYMENT` so we fetch contributor data on deploy builds again.

cc @yaili 