### PR TITLE
Add snapshot releases to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,16 @@ jobs:
 
       - name: Test
         run: yarn workspace @primer/gatsby-theme-doctocat test
+
+      - name: Create .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: Snapshot release
+        run: |
+          yarn changeset version --snapshot
+          yarn changeset publish --tag canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
-      - name: Snapshot release
+      - name: Release snapshot
         run: |
           yarn changeset version --snapshot
           yarn changeset publish --tag canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,5 @@ jobs:
         run: |
           yarn changeset version --snapshot
           yarn changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

When we replaced our [`@primer/publish`](https://github.com/primer/publish) workflow with [changesets]() in https://github.com/primer/doctocat/pull/189, we lost the canary builds that `@primer/publish` released for every commit. These canary releases were helpful for testing changes in other projects before the pull request was merging the changes into the main branch.

## Solution

This PR updates our CI workflow to publish [snapshot releases](https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md) (i.e. canary releases) for every commit.

![image](https://user-images.githubusercontent.com/4608155/95394218-da9e3600-08b0-11eb-8cc3-d53fceef0337.png)

Shoutout to @BinaryMuse for finding the snapshot releases docs! ✨ 
