### PR TITLE
Add /mobile to global navigation

### DIFF
--- a/.changeset/pretty-ligers-lay.md
+++ b/.changeset/pretty-ligers-lay.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": minor
+---
+
+Add https://primer.style/mobile link to the global navigation

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -12,6 +12,8 @@
       url: https://primer.style/presentations
     - title: Command line
       url: https://primer.style/cli
+    - title: Mobile
+      url: https://primer.style/mobile
 - title: Development
   children:
     - title: Primer CSS


### PR DESCRIPTION
This PR adds a https://primer.style/mobile link to the global navigation.