### PR TITLE
Add /view-components to global navigation

### DIFF
--- a/.changeset/gold-eagles-wink.md
+++ b/.changeset/gold-eagles-wink.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": minor
+---
+
+Add https://primer.style/view-components link to the global navigation

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -16,11 +16,11 @@
       url: https://primer.style/mobile
 - title: Development
   children:
-    - title: Primer CSS
+    - title: CSS
       url: https://primer.style/css
-    - title: Primer React
+    - title: React
       url: https://primer.style/components
-    - title: Primer ViewComponents
+    - title: ViewComponents
       url: https://primer.style/view-components
 - title: About
   url: https://primer.style/team

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -20,5 +20,7 @@
       url: https://primer.style/css
     - title: Primer React
       url: https://primer.style/components
+    - title: Primer ViewComponents
+      url: https://primer.style/view-components
 - title: About
   url: https://primer.style/team


### PR DESCRIPTION
This PR adds a https://primer.style/view-components link to the global navigation.