### PR TITLE
Remove border-radius on bottom border

### DIFF
--- a/.changeset/silver-wolves-play.md
+++ b/.changeset/silver-wolves-play.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Remove border-radius on bottom page border

--- a/theme/src/components/page-footer.js
+++ b/theme/src/components/page-footer.js
@@ -5,7 +5,7 @@ import Contributors from './contributors'
 
 function PageFooter({editUrl, contributors}) {
   return editUrl || contributors.length > 0 ? (
-    <BorderBox borderWidth={0} borderTopWidth={1} mt={8} py={5}>
+    <BorderBox borderWidth={0} borderTopWidth={1} borderRadius={0} mt={8} py={5}>
       <Grid gridGap={4}>
         {editUrl ? (
           <Link href={editUrl}>


### PR DESCRIPTION
@yaili noticed that there's a border-radius on the bottom of Doctocat pages:

![image](https://user-images.githubusercontent.com/4608155/97886454-79b22400-1cdd-11eb-830c-9bb71b327335.png)

This PR fixes that.

