### PR TITLE
Add /desktop to global navigation

### DIFF
--- a/.changeset/rude-beans-shave.md
+++ b/.changeset/rude-beans-shave.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": minor
+---
+
+Add https://primer.style/desktop link to the global navigation

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -14,6 +14,8 @@
       url: https://primer.style/cli
     - title: Mobile
       url: https://primer.style/mobile
+    - title: Desktop
+      url: https://primer.style/desktop
 - title: Development
   children:
     - title: CSS


### PR DESCRIPTION
This PR adds a https://primer.style/desktop link to the global navigation.