### PR TITLE
Remove prototyping link from design dropdown

### DIFF
--- a/.changeset/lazy-camels-search.md
+++ b/.changeset/lazy-camels-search.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": minor
+---
+
+Remove Prototyping link from Design dropdown in the global navigation

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -6,8 +6,6 @@
       url: https://primer.style/design
     - title: Octicons
       url: https://primer.style/octicons
-    - title: Prototyping
-      url: https://primer.style/css/tools/prototyping
     - title: Presentations
       url: https://primer.style/presentations
     - title: Command line


### PR DESCRIPTION
Removes the prototyping link from the design dropdown in the global navigation.