### PR TITLE
Update status enum to use more conventional naming

### DIFF
--- a/.changeset/stale-hotels-admire.md
+++ b/.changeset/stale-hotels-admire.md
@@ -1,0 +1,10 @@
+---
+"@primer/gatsby-theme-doctocat": minor
+---
+
+Update supported statuses
+
+```diff
+- New, Experimental, Review, Stable, Deprecated
++ Alpha, Beta, Stable, Deprecated
+```

--- a/docs/content/usage/front-matter.mdx
+++ b/docs/content/usage/front-matter.mdx
@@ -40,7 +40,7 @@ Doctocat comes with a few predefined statuses that have colors associated with t
 
 | Status         | Output                                | Meaning                                                                |
 | -------------- | ------------------------------------- |------------------------------------------------------------------------|
-| `Alpha`        | <StatusLabel status="Alpha" />        | Experimental. Usage requires review from a Design Systems team member. |
+| `Alpha`        | <StatusLabel status="Alpha" />        | Experimental. Breaking changes are likely. |
 | `Beta`         | <StatusLabel status="Beta" />         | Usage encouraged, but not required.                                    |
 | `Stable`       | <StatusLabel status="Stable" />       | Usage required.                                                        |
 | `Deprecated`   | <StatusLabel status="Deprecated" />   | Usage not allowed. May be removed at any time.                         |

--- a/docs/content/usage/front-matter.mdx
+++ b/docs/content/usage/front-matter.mdx
@@ -38,12 +38,12 @@ status: Stable
 
 Doctocat comes with a few predefined statuses that have colors associated with them:
 
-| Status         | Output                                |
-| -------------- | ------------------------------------- |
-| `Alpha`        | <StatusLabel status="Alpha" />        |
-| `Beta`         | <StatusLabel status="Beta" />         |
-| `Stable`       | <StatusLabel status="Stable" />       |
-| `Deprecated`   | <StatusLabel status="Deprecated" />   |
+| Status         | Output                                | Meaning                                                                |
+| -------------- | ------------------------------------- |------------------------------------------------------------------------|
+| `Alpha`        | <StatusLabel status="Alpha" />        | Experimental. Usage requires review from a Design Systems team member. |
+| `Beta`         | <StatusLabel status="Beta" />         | Usage encouraged, but not required.                                    |
+| `Stable`       | <StatusLabel status="Stable" />       | Usage required.                                                        |
+| `Deprecated`   | <StatusLabel status="Deprecated" />   | Usage not allowed. May be removed at any time.                         |
 
 Custom statuses will render a gray dot:
 

--- a/docs/content/usage/front-matter.mdx
+++ b/docs/content/usage/front-matter.mdx
@@ -40,10 +40,9 @@ Doctocat comes with a few predefined statuses that have colors associated with t
 
 | Status         | Output                                |
 | -------------- | ------------------------------------- |
+| `Alpha`        | <StatusLabel status="Alpha" />        |
+| `Beta`         | <StatusLabel status="Beta" />         |
 | `Stable`       | <StatusLabel status="Stable" />       |
-| `New`          | <StatusLabel status="New" />          |
-| `Experimental` | <StatusLabel status="Experimental" /> |
-| `Review`       | <StatusLabel status="Review" />       |
 | `Deprecated`   | <StatusLabel status="Deprecated" />   |
 
 Custom statuses will render a gray dot:

--- a/docs/content/usage/front-matter.mdx
+++ b/docs/content/usage/front-matter.mdx
@@ -42,7 +42,7 @@ Doctocat comes with a few predefined statuses that have colors associated with t
 | -------------- | ------------------------------------- |------------------------------------------------------------------------|
 | `Alpha`        | <StatusLabel status="Alpha" />        | Experimental. Breaking changes are likely. |
 | `Beta`         | <StatusLabel status="Beta" />         | Usage encouraged, but not required.                                    |
-| `Stable`       | <StatusLabel status="Stable" />       | Usage required.                                                        |
+| `Stable`       | <StatusLabel status="Stable" />       | Usage expected.                                                        |
 | `Deprecated`   | <StatusLabel status="Deprecated" />   | Usage not allowed. May be removed at any time.                         |
 
 Custom statuses will render a gray dot:

--- a/theme/src/components/status-label.js
+++ b/theme/src/components/status-label.js
@@ -4,9 +4,8 @@ import React from 'react'
 
 const STATUS_COLORS = {
   stable: 'green.6',
-  new: 'green.6',
-  experimental: 'yellow.7',
-  review: 'yellow.7',
+  beta: 'yellow.7',
+  alpha: 'red.6',
   deprecated: 'red.6',
 }
 

--- a/theme/src/components/status-label.js
+++ b/theme/src/components/status-label.js
@@ -3,9 +3,9 @@ import {DotFillIcon} from '@primer/octicons-react'
 import React from 'react'
 
 const STATUS_COLORS = {
-  stable: 'green.6',
-  beta: 'yellow.7',
   alpha: 'red.6',
+  beta: 'yellow.7',
+  stable: 'green.6',
   deprecated: 'red.6',
 }
 


### PR DESCRIPTION
## Problem

The meaning of the status values has proven to be confusing to some consumers.

## Solution

Update the status values to follow the conventional alpha, beta, stable, deprecated cycle.

This is arguably a breaking change in that the default values are decorated with a color in the theme and consumers that pull in this change will need to switch to this new naming to keep the colors we provide. Consumers can choose to not use this scheme if they are comfortable with grey dots.

Co-authored-by: Joel Hawksley <joelhawksley@github.com>