### PR TITLE
Open external links in new tab

### DIFF
--- a/.changeset/wise-bobcats-look.md
+++ b/.changeset/wise-bobcats-look.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': minor
+---
+
+Open external links in a new tab to avoid redirect conflicts.

--- a/theme/src/components/external-link.js
+++ b/theme/src/components/external-link.js
@@ -4,7 +4,7 @@ import React from 'react'
 
 function ExternalLink({href, children}) {
   return (
-    <Link href={href} lineHeight="condensedUltra" fontSize={1}>
+    <Link href={href} lineHeight="condensedUltra" fontSize={1} target="_blank">
       <StyledOcticon icon={LinkExternalIcon} mr={1} />
       {children}
     </Link>


### PR DESCRIPTION
This PR changes how external links behave. Currently we have two types of external links:

1. View code
2. View storybook

This is trying to mitigate an issue that currently occurs in https://primer.style/, more specifically the VIewComponents documentation.
When clicking on the `View storybook` button, the page redirects to the storybook root, instead of the selected component. But, when we `cmd + click` the button, it redirects correctly.

@colebemis suggested adding `target="_blank"` to mitigate this issue :)