### PR TITLE
Replace > with / in header

### DIFF
--- a/.changeset/two-ghosts-prove.md
+++ b/.changeset/two-ghosts-prove.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Replace `>` with `/` in the header

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -60,9 +60,14 @@ function Header({isSearchEnabled}) {
 
           {siteMetadata.shortName ? (
             <>
-              <Box display={['none', null, null, 'inline-block']} mx={2}>
-                <StyledOcticon icon={ChevronRightIcon} color="blue.4" />
-              </Box>
+              <Text
+                display={['none', null, null, 'inline-block']}
+                color="blue.4"
+                fontFamily="mono"
+                mx={2}
+              >
+                /
+              </Text>
               <Link as={GatsbyLink} to="/" color="blue.4" fontFamily="mono">
                 {siteMetadata.shortName}
               </Link>

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -1,10 +1,5 @@
-import {Box, Flex, Link, StyledOcticon, Sticky} from '@primer/components'
-import {
-  ChevronRightIcon,
-  MarkGithubIcon,
-  SearchIcon,
-  ThreeBarsIcon,
-} from '@primer/octicons-react'
+import {Box, Flex, Link, StyledOcticon, Sticky, Text} from '@primer/components'
+import {MarkGithubIcon, SearchIcon, ThreeBarsIcon} from '@primer/octicons-react'
 import {Link as GatsbyLink} from 'gatsby'
 import React from 'react'
 import {ThemeContext} from 'styled-components'


### PR DESCRIPTION
This PR replaces the `>` in the header with a `/` because `/` is more consistent with how we represent hierarchy at GitHub.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4608155/110138134-811a3480-7d86-11eb-9982-16b06732afea.png) |  ![image](https://user-images.githubusercontent.com/4608155/110138199-91321400-7d86-11eb-9a8d-b02152f3db4f.png) |