### PR TITLE
Reduce table of contents depth

### DIFF
--- a/.changeset/beige-keys-boil.md
+++ b/.changeset/beige-keys-boil.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Reduce table of contents depth (only list `h2`s)

--- a/.changeset/beige-keys-boil.md
+++ b/.changeset/beige-keys-boil.md
@@ -1,5 +1,5 @@
 ---
-"@primer/gatsby-theme-doctocat": patch
+"@primer/gatsby-theme-doctocat": minor
 ---
 
 Reduce table of contents depth (only list `h2`s)

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -17,7 +17,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
         nodes {
           fileAbsolutePath
           rawBody
-          tableOfContents(maxDepth: 3)
+          tableOfContents(maxDepth: 2)
           parent {
             ... on File {
               relativeDirectory


### PR DESCRIPTION
## Problem

The table of contents can get very long on pages with a lot of headings.

## Solution

This PR updates the table of contents to only display `h2`s (previously we also displayed `h3`s). 

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4608155/110140872-6a291180-7d89-11eb-915f-ac8e57a87936.png) | ![image](https://user-images.githubusercontent.com/4608155/110141030-95abfc00-7d89-11eb-9d60-d9573410831f.png) |


Closes https://github.com/primer/doctocat/issues/206