### PR TITLE
Fix scroll flickering of table of contents

### DIFF
--- a/.changeset/fifty-rocks-complain.md
+++ b/.changeset/fifty-rocks-complain.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Fix scroll flickering of table of contents

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -65,8 +65,8 @@ function Layout({children, pageContext}) {
               display={['none', null, 'block']}
               css={{gridArea: 'table-of-contents', overflow: 'auto'}}
               position="sticky"
-              top={HEADER_HEIGHT + 24}
-              maxHeight={`calc(100vh - ${HEADER_HEIGHT}px - 24px)`}
+              top={HEADER_HEIGHT + 48}
+              maxHeight={`calc(100vh - ${HEADER_HEIGHT}px - 48px)`}
             >
               <Text display="inline-block" fontWeight="bold" mb={1}>
                 On this page


### PR DESCRIPTION
Increase the height to match biggest ``padding`` set by screen media CSS

![image](https://user-images.githubusercontent.com/2181866/135711808-de724917-fad9-42cf-91c0-bc35baf12ec6.png)

Before:

![scroll-old](https://user-images.githubusercontent.com/2181866/135711739-5546efe9-6238-456a-96ea-d85873c4e6c6.gif)

After:

![scroll-new](https://user-images.githubusercontent.com/2181866/135711744-f16a16b8-7253-4b43-a1f9-6016829a4aa1.gif)

