### PR TITLE
Output components.json file

### DIFF
--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -2,6 +2,7 @@
 title: Caption
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
+componentId: caption
 ---
 
 The caption component can be used to append a caption to images used in documentation.

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -2,6 +2,7 @@
 title: Caption
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
+component_id: caption
 ---
 
 The caption component can be used to append a caption to images used in documentation.

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -2,7 +2,7 @@
 title: Caption
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
-component_id: caption
+componentId: caption
 ---
 
 The caption component can be used to append a caption to images used in documentation.

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -2,7 +2,6 @@
 title: Caption
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
-componentId: caption
 ---
 
 The caption component can be used to append a caption to images used in documentation.

--- a/docs/content/components/do-dont.mdx
+++ b/docs/content/components/do-dont.mdx
@@ -2,7 +2,7 @@
 title: Do/Don't
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/do-dont.js
-component_id: do_dont
+componentId: do_dont
 ---
 
 Use the `Do` and `Dont` components to provide good and bad examples within documentation.

--- a/docs/content/components/do-dont.mdx
+++ b/docs/content/components/do-dont.mdx
@@ -2,7 +2,6 @@
 title: Do/Don't
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/do-dont.js
-componentId: do_dont
 ---
 
 Use the `Do` and `Dont` components to provide good and bad examples within documentation.

--- a/docs/content/components/do-dont.mdx
+++ b/docs/content/components/do-dont.mdx
@@ -2,6 +2,7 @@
 title: Do/Don't
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/do-dont.js
+component_id: do_dont
 ---
 
 Use the `Do` and `Dont` components to provide good and bad examples within documentation.

--- a/docs/content/components/note.mdx
+++ b/docs/content/components/note.mdx
@@ -2,6 +2,7 @@
 title: Note
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/note.js
+componentId: note
 ---
 
 Use the `Note` component to call out information in documentation pages.

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -83,7 +83,7 @@ exports.onPostBuild = async ({graphql}) => {
           path
           context {
             frontmatter {
-              component_id
+              componentId
               status
             }
           }
@@ -94,7 +94,7 @@ exports.onPostBuild = async ({graphql}) => {
 
   const components = data.allSitePage.nodes.map(node => {
     return {
-      component_id: node.context.frontmatter.component_id,
+      id: node.context.frontmatter.componentId,
       path: node.path,
       status: node.context.frontmatter.status.toLowerCase()
     }

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -76,31 +76,35 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
 }
 
 exports.onPostBuild = async ({graphql}) => {
-  const {data} = await graphql(`
-    query {
-      allSitePage(filter: {context: {frontmatter: {componentId: {ne: null}}}}) {
-        nodes {
-          path
-          context {
-            frontmatter {
-              componentId
-              status
+  try {
+    const {data} = await graphql(`
+      query {
+        allSitePage(filter: {context: {frontmatter: {componentId: {ne: null}}}}) {
+          nodes {
+            path
+            context {
+              frontmatter {
+                componentId
+                status
+              }
             }
           }
         }
       }
-    }
-  `)
+    `)
 
-  const components = data.allSitePage.nodes.map(node => {
-    return {
-      id: node.context.frontmatter.componentId,
-      path: node.path,
-      status: node.context.frontmatter.status.toLowerCase()
-    }
-  })
+    const components = data.allSitePage.nodes.map(node => {
+      return {
+        id: node.context.frontmatter.componentId,
+        path: node.path,
+        status: node.context.frontmatter.status.toLowerCase()
+      }
+    })
 
-  fs.writeFileSync(path.resolve(process.cwd(), 'public/components.json'), JSON.stringify(components))
+    fs.writeFileSync(path.resolve(process.cwd(), 'public/components.json'), JSON.stringify(components))
+  } catch (error) {
+    console.warn('Unable to build components.json')
+  }
 }
 
 function getEditUrl(repo, filePath, defaultBranch) {

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -13,7 +13,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
   const repo = getPkgRepo(readPkgUp.sync().package)
 
   const {data} = await graphql(`
-    {
+    query {
       allMdx {
         nodes {
           fileAbsolutePath
@@ -77,7 +77,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
 
 exports.onPostBuild = async ({graphql}) => {
   const {data} = await graphql(`
-    {
+    query {
       allSitePage(filter: {context: {frontmatter: {component_id: {ne: null}}}}) {
         nodes {
           path

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -78,7 +78,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
 exports.onPostBuild = async ({graphql}) => {
   const {data} = await graphql(`
     query {
-      allSitePage(filter: {context: {frontmatter: {component_id: {ne: null}}}}) {
+      allSitePage(filter: {context: {frontmatter: {componentId: {ne: null}}}}) {
         nodes {
           path
           context {

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -103,6 +103,8 @@ exports.onPostBuild = async ({graphql}) => {
 
     fs.writeFileSync(path.resolve(process.cwd(), 'public/components.json'), JSON.stringify(components))
   } catch (error) {
+    // This is not necessarily an error, so we just log a warning instead of failing the build.
+    // Some sites won't have any markdown files with `componentId` frontmatter and that's okay.
     console.warn('Unable to build components.json')
   }
 }


### PR DESCRIPTION
## Objective

We need a way to get component statuses from the [ViewComponent](https://primer.style/view-components) and [React](https://primer.style/react) libraries to build a [cross-implementation status page](https://github.com/github/primer/issues/114).

## Solution

This PR adds a step to the Doctocat build process that will output a `components.json` file with component status info if the site that its building has markdown files containing `componentId` frontmatter. Example:

### Example


[primer/react](https://github.com/primer/react): `docs/content/Avatar.mdx`
```md
---
componentId: avatar
status: Alpha
source: #
---

...
```
↓
```
gatsby build
```
↓

`https://primer.style/react/components.json`
```js
[
  {
    id: 'avatar',
    path: '/Avatar',
    status: 'alpha'
  },
 ...
]
```

---

Co-author: @pouretrebelle 



