### PR TITLE
fix: guard against missing status property in front-matter

### DIFF
--- a/.changeset/tame-students-prove.md
+++ b/.changeset/tame-students-prove.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Only add pages that have `componentId` and `status` to `components.json`

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -79,7 +79,7 @@ exports.onPostBuild = async ({graphql}) => {
   try {
     const {data} = await graphql(`
       query {
-        allSitePage(filter: {context: {frontmatter: {componentId: {ne: null}}}}) {
+        allSitePage(filter: {context: {frontmatter: {componentId: {ne: null}, status: {ne: null}}}}) {
           nodes {
             path
             context {
@@ -93,24 +93,13 @@ exports.onPostBuild = async ({graphql}) => {
       }
     `)
 
-    const components = data.allSitePage.nodes.reduce((metadataArr, node) => {
-      const {
-        path,
-        context: {
-          frontmatter: {status, componentId}
-        }
-      } = node
-      if (status && componentId) {
-        metadataArr.push({
-          id: componentId,
-          path: path,
-          status: status.toLowerCase()
-        })
+    const components = data.allSitePage.nodes.map(node => {
+      return {
+        id: node.context.frontmatter.componentId,
+        path: node.path,
+        status: node.context.frontmatter.status.toLowerCase()
       }
-      return metadataArr
-    }, [])
-
-    console.log(123456, components)
+    })
 
     fs.writeFileSync(path.resolve(process.cwd(), 'public/components.json'), JSON.stringify(components))
   } catch (error) {

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -93,13 +93,24 @@ exports.onPostBuild = async ({graphql}) => {
       }
     `)
 
-    const components = data.allSitePage.nodes.map(node => {
-      return {
-        id: node.context.frontmatter.componentId,
-        path: node.path,
-        status: node.context.frontmatter.status.toLowerCase()
+    const components = data.allSitePage.nodes.reduce((metadataArr, node) => {
+      const {
+        path,
+        context: {
+          frontmatter: {status, componentId}
+        }
+      } = node
+      if (status && componentId) {
+        metadataArr.push({
+          id: componentId,
+          path: path,
+          status: status.toLowerCase()
+        })
+        return metadataArr
       }
-    })
+    }, [])
+
+    console.log(123456, components)
 
     fs.writeFileSync(path.resolve(process.cwd(), 'public/components.json'), JSON.stringify(components))
   } catch (error) {

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -106,8 +106,8 @@ exports.onPostBuild = async ({graphql}) => {
           path: path,
           status: status.toLowerCase()
         })
-        return metadataArr
       }
+      return metadataArr
     }, [])
 
     console.log(123456, components)


### PR DESCRIPTION
## Summary

Adds another filter guard to post-build step query that is used to generate the components.json.

If frontmatter doesn't include _both_ `componentId` and `status`, the `components.json` doesn't get built. This prevents the [status page ](https://primer.style/status/) from being displayed. 

I'm proposing that you make status a required parameter too, to ensure we don't fail the creation of that file on the basis of a single file having a missing property.