### PR TITLE
Exploration: Use ActionList2 as navigation

### DIFF
--- a/docs/content/usage/customization.mdx
+++ b/docs/content/usage/customization.mdx
@@ -3,7 +3,7 @@ title: Customization
 description: Here are a few ways you can customize your Doctocat site.
 ---
 
-import {BorderBox} from '@primer/components'
+import {BorderBox} from '@primer/react'
 import {Contributors} from '@primer/gatsby-theme-doctocat'
 
 ## Site metadata
@@ -141,7 +141,7 @@ To use a custom hero component, [shadow](https://www.gatsbyjs.org/blog/2019-04-2
 
 ```jsx
 // src/@primer/gatsby-theme-doctocat/components/hero.js
-import {Box} from '@primer/components'
+import {Box} from '@primer/react'
 import React from 'react'
 
 export default function Hero() {

--- a/docs/content/usage/front-matter.mdx
+++ b/docs/content/usage/front-matter.mdx
@@ -2,7 +2,7 @@
 title: Front matter
 ---
 
-import {BorderBox} from '@primer/components'
+import {BorderBox} from '@primer/react'
 import {StatusLabel} from '@primer/gatsby-theme-doctocat'
 import StorybookLink from '@primer/gatsby-theme-doctocat/src/components/storybook-link'
 import SourceLink from '@primer/gatsby-theme-doctocat/src/components/source-link'

--- a/docs/content/usage/live-code.mdx
+++ b/docs/content/usage/live-code.mdx
@@ -31,7 +31,7 @@ You can add variables to the global scope of live previews by [shadowing](https:
 
 ```js
 // src/@primer/gatsby-theme-doctocat/live-code-scope.js
-import {Box} from '@primer/components'
+import {Box} from '@primer/react'
 
 export default {
   Box,

--- a/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
@@ -1,4 +1,4 @@
-import * as primerComponents from '@primer/components'
+import * as primerComponents from '@primer/react'
 import * as doctocatComponents from '@primer/gatsby-theme-doctocat'
 
 export default {...primerComponents, ...doctocatComponents}

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -1,6 +1,8 @@
 - title: Getting started
   url: /getting-started
   children:
+    - title: Getting started
+      url: /getting-started
     - title: Gatsby CLI
       url: /getting-started/gatsby-cli
 - title: Usage

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -1,5 +1,6 @@
 import {BorderBox, Flex, Link, Text, Button, ThemeProvider} from '@primer/react'
 import {ChevronDownIcon, ChevronUpIcon, XIcon} from '@primer/octicons-react'
+import {ActionList} from '@primer/react/lib-esm/drafts'
 import {Link as GatsbyLink} from 'gatsby'
 import debounce from 'lodash.debounce'
 import React from 'react'
@@ -88,6 +89,7 @@ function PrimerNavItems({items}) {
         key={item.title}
         sx={{borderWidth: 0, borderRadius: 0, borderTopWidth: index !== 0 ? 1 : 0, borderColor: 'border.muted', p: 4}}
       >
+        boundaries
         {item.children ? (
           <Details key={index}>
             {({open, toggle}) => (

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -1,6 +1,5 @@
 import {BorderBox, Flex, Link, Text, Button, ThemeProvider} from '@primer/react'
 import {ChevronDownIcon, ChevronUpIcon, XIcon} from '@primer/octicons-react'
-import {ActionList} from '@primer/react/lib-esm/drafts'
 import {Link as GatsbyLink} from 'gatsby'
 import debounce from 'lodash.debounce'
 import React from 'react'
@@ -89,7 +88,6 @@ function PrimerNavItems({items}) {
         key={item.title}
         sx={{borderWidth: 0, borderRadius: 0, borderTopWidth: index !== 0 ? 1 : 0, borderColor: 'border.muted', p: 4}}
       >
-        boundaries
         {item.children ? (
           <Details key={index}>
             {({open, toggle}) => (

--- a/theme/src/components/nav-items.js
+++ b/theme/src/components/nav-items.js
@@ -1,9 +1,8 @@
-import {Box, Link, StyledOcticon, themeGet} from '@primer/react'
+import {ActionList} from '@primer/react/lib-esm/drafts'
 import {LinkExternalIcon} from '@primer/octicons-react'
 import {Link as GatsbyLink} from 'gatsby'
 import preval from 'preval.macro'
 import React from 'react'
-import styled from 'styled-components'
 
 // This code needs to run at build-time so it can access the file system.
 const repositoryUrl = preval`
@@ -17,70 +16,58 @@ const repositoryUrl = preval`
   }
 `
 
-const NavLink = styled(Link)`
-  &.active {
-    font-weight: ${themeGet('fontWeights.bold')};
-    color: ${themeGet('colors.fg.default')};
-  }
-`
-
 function NavItems({items}) {
   return (
-    <>
-      {items.map(item => (
-        <Box
-          key={item.title}
-          borderWidth={0}
-          borderRadius={0}
-          borderTopWidth={1}
-          borderStyle="solid"
-          borderColor="border.muted"
-          p={4}
-        >
-          <Box display="flex" flexDirection="column">
-            <NavLink
-              as={GatsbyLink}
-              to={item.url}
-              activeClassName="active"
-              partiallyActive={true}
-              sx={{color: 'inherit'}}
-            >
-              {item.title}
-            </NavLink>
-            {item.children ? (
-              <Box display="flex" flexDirection="column" mt={2}>
+    <ActionList
+      sx={{
+        m: 2,
+        'a[aria-current]': {
+          position: 'relative',
+          bg: 'actionListItem.default.selectedBg',
+          '::after': {
+            content: '""',
+            position: 'absolute',
+            top: 'calc(50% - 12px)',
+            left: '-8px',
+            width: 4,
+            height: 24,
+            bg: 'accent.fg',
+            borderRadius: 6
+          }
+        }
+      }}
+    >
+      {items.map(item => {
+        if (item.children) {
+          return (
+            <>
+              <ActionList.Group title={item.title}>
                 {item.children.map(child => (
-                  <NavLink
-                    key={child.title}
-                    as={GatsbyLink}
-                    to={child.url}
-                    activeClassName="active"
-                    sx={{
-                      display: 'block',
-                      py: 1,
-                      mt: 2,
-                      fontSize: 1
-                    }}
-                  >
+                  <ActionList.LinkItem key={child.url} as={GatsbyLink} to={child.url}>
                     {child.title}
-                  </NavLink>
+                  </ActionList.LinkItem>
                 ))}
-              </Box>
-            ) : null}
-          </Box>
-        </Box>
-      ))}
+              </ActionList.Group>
+              <ActionList.Divider />
+            </>
+          )
+        } else {
+          return (
+            <ActionList.LinkItem key={item.url} href={item.url} activeClassName="active">
+              {item.title}
+            </ActionList.LinkItem>
+          )
+        }
+      })}
       {repositoryUrl ? (
-        <Box borderWidth={0} borderTopWidth={1} borderRadius={0} borderStyle="solid" borderColor="border.default" p={4}>
-          <Link href={repositoryUrl} sx={{color: 'inherit'}}>
-            <Box display="flex" justifyContent="space-between" alignItems="center">
-              GitHub
-              <StyledOcticon icon={LinkExternalIcon} sx={{color: 'fg.muted'}} />
-            </Box>
-          </Link>
-        </Box>
+        <ActionList.LinkItem href={repositoryUrl} target="_blank">
+          GitHub
+          <ActionList.TrailingVisual>
+            <LinkExternalIcon />
+          </ActionList.TrailingVisual>
+        </ActionList.LinkItem>
       ) : null}
-    </>
+    </ActionList>
   )
 }
 

--- a/theme/src/components/sidebar.js
+++ b/theme/src/components/sidebar.js
@@ -1,4 +1,4 @@
-import {BorderBox, Flex, Position} from '@primer/react'
+import {Box, Flex, Position} from '@primer/react'
 import React from 'react'
 import navItems from '../nav.yml'
 import {HEADER_HEIGHT} from './header'
@@ -40,15 +40,11 @@ function Sidebar() {
         minWidth: 260
       }}
     >
-      <BorderBox
-        {...scrollContainerProps}
-        style={{overflow: 'auto'}}
-        sx={{borderWidth: 0, borderRightWidth: 1, borderRadius: 0, height: '100%'}}
-      >
+      <Box {...scrollContainerProps} style={{overflow: 'auto'}} sx={{height: '100%'}}>
         <Flex sx={{flexDirection: 'column'}}>
           <NavItems items={navItems} />
         </Flex>
-      </BorderBox>
+      </Box>
     </Position>
   )
 }

--- a/theme/src/components/sidebar.js
+++ b/theme/src/components/sidebar.js
@@ -37,8 +37,7 @@ function Sidebar() {
         position: 'sticky',
         top: HEADER_HEIGHT,
         height: `calc(100vh - ${HEADER_HEIGHT}px)`,
-        minWidth: 260,
-        bg: 'canvas.subtle'
+        minWidth: 260
       }}
     >
       <BorderBox


### PR DESCRIPTION
Inspired by [Navigation List](https://github.com/github/github/pull/199777) component, moving the common nav for our docs to an ActionList based on :)


| Before        | After           |
| ------------- |-------------|
|  ![image](https://user-images.githubusercontent.com/1863771/149527986-dd6b61c1-d6d4-468a-884c-3e8345ed3ea3.png) | ![image](https://user-images.githubusercontent.com/1863771/149536687-b7d8cfac-9402-4e3b-816e-f960f5ce8964.png) |
| ![image](https://user-images.githubusercontent.com/1863771/149528035-3cd4ef8b-805c-4e20-8984-3ae71dce3488.png) | ![image](https://user-images.githubusercontent.com/1863771/149536754-1cf3c16f-36b2-45ef-acfc-10e7328070e7.png) |


Things to think about:
1. I used groups instead of nested subnav because we don't have a lot of nesting.
2. Accidental bug or bug-fix: Group title are no longer routes, which is good for headers that are just empty pages: [usage](https://primer.style/doctocat/usage) but a bug for pages that had some content like [components](https://primer.style/doctocat/components)
3. Might want to align the top starting point for the nav and content header [screenshot](https://user-images.githubusercontent.com/1863771/149530903-58b33f83-dfbc-41bb-a680-197b55fdaeb1.png)
4. Homepage hero looks very odd without a sidebar border 😅 [screenshot](https://user-images.githubusercontent.com/1863771/149537260-5bb7c309-b773-4af7-8118-14db41bf68b3.png)