### PR TITLE
Update default editUrl branch to main

### DIFF
--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -44,7 +44,7 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
       const rootAbsolutePath = path.resolve(process.cwd(), themeOptions.repoRootPath || '.')
 
       const fileRelativePath = path.relative(rootAbsolutePath, node.fileAbsolutePath)
-      const defaultBranch = themeOptions.defaultBranch || 'master'
+      const defaultBranch = themeOptions.defaultBranch || 'main'
       const editUrl = getEditUrl(repo, fileRelativePath, defaultBranch)
 
       let contributors = []


### PR DESCRIPTION
```diff
- const defaultBranch = themeOptions.defaultBranch || 'master'
+ const defaultBranch = themeOptions.defaultBranch || 'main'
```

Note: This would be a breaking change for folks that use `master` as the default branch.

Sidenote: We should probably replace other places where master is used. Quick search: https://github.com/primer/doctocat/search?q=master