### PR TITLE
Update do/dont visual style, add `indented` prop

### DIFF
--- a/.changeset/clever-lions-kiss.md
+++ b/.changeset/clever-lions-kiss.md
@@ -1,0 +1,6 @@
+---
+'docs': minor
+'@primer/gatsby-theme-doctocat': minor
+---
+
+New visual styles for Do/Dont components

--- a/.changeset/clever-lions-kiss.md
+++ b/.changeset/clever-lions-kiss.md
@@ -1,5 +1,4 @@
 ---
-'docs': minor
 '@primer/gatsby-theme-doctocat': minor
 ---
 

--- a/docs/content/components/do-dont.mdx
+++ b/docs/content/components/do-dont.mdx
@@ -45,3 +45,18 @@ The `DoDontContainer` component also accepts a `stacked` prop to create stacked 
   </Dont>
 </DoDontContainer>
 ```
+
+### Indented
+
+`Do` and `Dont` components can also be indented to increase the clarity of the example message within the documentation:
+
+```jsx live
+<DoDontContainer stacked>
+  <Do indented>
+    Place pane regions on the left to display navigation, filtering, or an overview for entities such as users, bots, apps, etc.
+  </Do>
+  <Dont indented>
+    Don't display more than three columns of information on a page.
+  </Dont>
+</DoDontContainer>
+```

--- a/theme/src/components/do-dont.js
+++ b/theme/src/components/do-dont.js
@@ -15,22 +15,48 @@ DoDontContainer.defaultProps = {
 }
 
 export function Do(props) {
-  return <DoDontBase {...props} title="Do" icon={CheckCircleFillIcon} iconBg="success.fg" />
+  return <DoDontBase {...props} title="Do" bg="success.fg" borderColor="success.subtle" />
 }
 
 export function Dont(props) {
-  return <DoDontBase {...props} title="Don't" icon={XCircleFillIcon} iconBg="danger.fg" />
+  return <DoDontBase {...props} title="Don’t" bg="danger.fg" borderColor="danger.subtle" />
 }
 
-function DoDontBase({children, title, icon: Icon, iconBg}) {
+function DoDontBase({children, title, bg, borderColor, indented}) {
   return (
     <Box sx={{display: 'flex', flexDirection: 'column'}}>
-      <Box sx={{display: 'flex', alignSelf: 'start', flexDirection: 'row', alignItems: 'center', mb: '2'}}>
-        <StyledOcticon icon={Icon} sx={{color: iconBg}} />
-        <Text sx={{fontWeight: 'bold', color: 'fg.default', ml: 2}}>{title}</Text>
+      <Box
+        sx={{
+          display: 'flex',
+          alignSelf: 'start',
+          flexDirection: 'row',
+          alignItems: 'center',
+          mb: '2',
+          backgroundColor: bg,
+          borderRadius: '2',
+          color: 'fg.onEmphasis',
+          paddingX: '2'
+        }}
+      >
+        <Text sx={{fontWeight: 'bold', fontSize: '1', color: 'fg.onEmphasis'}}>{title}</Text>
       </Box>
       <Box sx={{'& *:last-child': {mb: 0}, img: {maxWidth: '100%'}, display: 'flex', flexDirection: 'column'}}>
-        {children}
+        {indented ? (
+          <Box
+            as="blockquote"
+            sx={{
+              margin: '0',
+              borderLeftWidth: '4px',
+              borderLeftStyle: 'solid',
+              borderLeftColor: borderColor,
+              paddingLeft: '3'
+            }}
+          >
+            {children}
+          </Box>
+        ) : (
+          children
+        )}
       </Box>
     </Box>
   )

--- a/theme/src/components/do-dont.js
+++ b/theme/src/components/do-dont.js
@@ -1,5 +1,4 @@
 import {Box, StyledOcticon, Text} from '@primer/react'
-import {CheckCircleFillIcon, XCircleFillIcon} from '@primer/octicons-react'
 import React from 'react'
 
 export function DoDontContainer({stacked, children}) {
@@ -15,11 +14,11 @@ DoDontContainer.defaultProps = {
 }
 
 export function Do(props) {
-  return <DoDontBase {...props} title="Do" bg="success.fg" borderColor="success.subtle" />
+  return <DoDontBase {...props} title="Do" bg="success.fg" borderColor="success.muted" />
 }
 
 export function Dont(props) {
-  return <DoDontBase {...props} title="Don’t" bg="danger.fg" borderColor="danger.subtle" />
+  return <DoDontBase {...props} title="Don’t" bg="danger.fg" borderColor="danger.muted" />
 }
 
 function DoDontBase({children, title, bg, borderColor, indented}) {


### PR DESCRIPTION
This PR updates some small visual styles, and adds an `indented` prop to the `Do` and `Dont` components. These changes aim to increase the clarity of when an example message appears within the documentation.

More design details behind this proposal can be seen on [this Figma file](https://www.figma.com/file/dsaSEL7aUeAgwksWZdiBIw/FY22-Q3---PageLayout-%2B-SplitPageLayout?node-id=17%3A9144) (only available for hubbers).

## Before
![Screen Shot 2022-03-01 at 15 20 36](https://user-images.githubusercontent.com/293280/156265420-e6fd46c1-0ff8-4522-9175-dfa38bdc85e9.png)

## After
![Screen Shot 2022-03-03 at 12 34 03](https://user-images.githubusercontent.com/293280/156648336-118a0057-289e-4ca8-8a90-6a5ddf153e65.png)
