### PR TITLE
Replace branch name master with main

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -5,4 +5,4 @@ with multi-package repos, or single-package repos to help you version and publis
 find the full documentation for it [in our repository](https://github.com/changesets/changesets)
 
 We have a quick list of common questions to get you started engaging with this project in
-[our documentation](https://github.com/changesets/changesets/blob/master/docs/common-questions.md)
+[our documentation](https://github.com/changesets/changesets/blob/main/docs/common-questions.md)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up Node.js
-        uses: actions/setup-node@master
+        uses: actions/setup-node@main
         with:
           node-version: 12
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Create release pull request or publish to npm
         id: changesets
-        uses: changesets/action@master
+        uses: changesets/action@main
         with:
           title: Release Tracking
           # This expects you to have a script called release which does a build for your packages and calls changeset publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,9 @@ We appreciate your contribution and hope that this document helps you along the 
 
 <Note>
 
-
 These guidelines are for contributing to the theme itself, if you are looking for help running a Doctocat site for another project locally, check out the [Local Development](/usage/local-development) docs in the Usage section.
 
 </Note>
-
 
 ## Local development
 
@@ -18,11 +16,9 @@ Run the following commands to begin local development:
 
 <Note>
 
-
 These steps require [Node.js](https://nodejs.org) and [Yarn](https://yarnpkg.com) to be set up locally.
 
 </Note>
-
 
 ```shell
 # Clone the repository
@@ -136,15 +132,18 @@ Follow this process if you'd like your work considered for inclusion in the proj
 - If you cloned a while ago, get the latest changes from upstream:
 
   ```shell
-  git checkout master
-  git pull upstream master
+  git checkout main
+  git pull upstream main
   ```
 
-- Create a new topic branch (off of the `master` branch) to contain your feature, change, or fix:
+- Create a new mainbranch (off of the `main` branch) to contain your feature, change, or fix:
+  main
 
-  ```shell
+  ````shell
   git checkout -b <topic-branch-name>
-  ```
+  ```main
+
+  ````
 
 - Install the dependencies:
 
@@ -164,10 +163,11 @@ Follow this process if you'd like your work considered for inclusion in the proj
 - Locally merge (or rebase) the upstream development branch into your topic branch:
 
   ```shell
-  git pull [--rebase] upstream master
+  git pull [--rebase] upstream main
   ```
 
 - Push your topic branch up to your fork:
+  main
 
   ```shell
   git push origin <topic-branch-name>

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -1,7 +1,7 @@
 ---
 title: Caption
 status: New
-source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
+source: https://github.com/primer/doctocat/blob/main/theme/src/components/caption.js
 componentId: caption
 ---
 
@@ -25,8 +25,6 @@ The caption component can be used to append a caption to images used in document
 
 <Note variant="warning">
 
-
 Be sure to provide enough detail in your caption so users with assistive technology have adequate context. An empty alt tag `alt=""` should be used on the `img` in cases where the caption describes the image, thus making the image decorative in purpose.
 
 </Note>
-

--- a/docs/content/components/do-dont.mdx
+++ b/docs/content/components/do-dont.mdx
@@ -1,7 +1,7 @@
 ---
 title: Do/Don't
 status: New
-source: https://github.com/primer/doctocat/blob/master/theme/src/components/do-dont.js
+source: https://github.com/primer/doctocat/blob/main/theme/src/components/do-dont.js
 ---
 
 Use the `Do` and `Dont` components to provide good and bad examples within documentation.
@@ -53,7 +53,8 @@ The `DoDontContainer` component also accepts a `stacked` prop to create stacked 
 ```jsx live
 <DoDontContainer stacked>
   <Do indented>
-    Place pane regions on the left to display navigation, filtering, or an overview for entities such as users, bots, apps, etc.
+    Place pane regions on the left to display navigation, filtering, or an
+    overview for entities such as users, bots, apps, etc.
   </Do>
   <Dont indented>
     Don't display more than three columns of information on a page.

--- a/docs/content/components/image-container.mdx
+++ b/docs/content/components/image-container.mdx
@@ -1,7 +1,7 @@
 ---
 title: ImageContainer
 status: New
-source: https://github.com/primer/doctocat/blob/master/theme/src/components/image-container.js
+source: https://github.com/primer/doctocat/blob/main/theme/src/components/image-container.js
 ---
 
 Use the `ImageContainer` component to contain images in documentation pages.

--- a/docs/content/components/note.mdx
+++ b/docs/content/components/note.mdx
@@ -1,7 +1,7 @@
 ---
 title: Note
 status: New
-source: https://github.com/primer/doctocat/blob/master/theme/src/components/note.js
+source: https://github.com/primer/doctocat/blob/main/theme/src/components/note.js
 componentId: note
 ---
 

--- a/docs/content/usage/deployment.mdx
+++ b/docs/content/usage/deployment.mdx
@@ -121,7 +121,7 @@ This is necessary because when your project lives in a subdirectory, there isn't
 
 ### 4. Update now.json in primer/primer.style
 
-After everything is set up in your repository, open a pull request on the [primer/primer.style](https://github.com/primer/primer.style) repository to add your site to the `routes` list in [now.json](https://github.com/primer/primer.style/blob/master/now.json):
+After everything is set up in your repository, open a pull request on the [primer/primer.style](https://github.com/primer/primer.style) repository to add your site to the `routes` list in [now.json](https://github.com/primer/primer.style/blob/main/now.json):
 
 ```diff
 // now.json in primer/primer.style


### PR DESCRIPTION
I found there are some places in this codebase referencing old branch name `master`.
I confirmed all workflow actions referencing `@master` is now using `main` branch as default branch.

Since there's no update in main codebase, no need to add changeset?