### PR TITLE
Update the link styling for primer.style

### DIFF
--- a/.changeset/quick-berries-fry.md
+++ b/.changeset/quick-berries-fry.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Added underlines to links in markdown documents

--- a/theme/src/components/link.js
+++ b/theme/src/components/link.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+import themeGet from '@styled-system/theme-get'
+
+const Link = styled.a`
+  text-decoration: underline;
+  text-underline-offset: 25%;
+  color: ${themeGet('colors.accent.fg')};
+`
+
+export default Link

--- a/theme/src/components/wrap-root-element.js
+++ b/theme/src/components/wrap-root-element.js
@@ -1,5 +1,6 @@
 import {MDXProvider} from '@mdx-js/react'
-import {Link, ThemeProvider} from '@primer/react'
+import {ThemeProvider} from '@primer/react'
+import Link from './link'
 import React from 'react'
 import mdxComponents from '../mdx-components'
 import Blockquote from './blockquote'


### PR DESCRIPTION
Giving our links in our markdown documents the underline style.

**Before**
![Paragraph without underlined links](https://user-images.githubusercontent.com/40274682/161144724-8c5e5f64-ff9d-47f4-a1c8-77cf3c3b94ab.png)

**After**
![Paragraph with underlined links](https://user-images.githubusercontent.com/40274682/161144642-71090356-51f9-4e4a-8a2c-cef73dce6c0b.png)
