### PR TITLE
Add line highlighting for live code blocks

### DIFF
--- a/docs/content/usage/live-code.mdx
+++ b/docs/content/usage/live-code.mdx
@@ -55,6 +55,35 @@ Every property on the object exported by `live-code-scope.js` will be available 
 ```
 ````
 
+## Line highlighting
+
+If you want to emphasize a particular range of lines, use the `highlight` attribute on the code block. The expected format is `higlight=start-end`. The line highlighting will disappear when the live example is edited.
+
+
+````markdown
+``` jsx live highlight=2-4
+<div>
+  <p>
+    This paragraph element should be higlighted.
+  </p>
+  <p>
+    This paragraph element should not be higlighted.
+  </p>
+</div>
+```
+````
+
+``` jsx live highlight=2-4
+<div>
+  <p>
+    This paragraph element should be higlighted.
+  </p>
+  <p>
+    This paragraph element should not be higlighted.
+  </p>
+</div>
+```
+
 ## Global styles
 
 Live previews are completely isolated from the rest of the page because they are rendered inside [iframes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). This means that you can apply global styles inside live previews without affecting the rest of the page:

--- a/theme/src/components/code.js
+++ b/theme/src/components/code.js
@@ -6,12 +6,14 @@ import Prism from '../prism'
 import ClipboardCopy from './clipboard-copy'
 import LiveCode from './live-code'
 
-function Code({className, children, live, noinline, metastring}) {
+function Code({className, children, live, highlight, noinline, metastring}) {
   const language = className ? className.replace(/language-/, '') : ''
   const code = children.trim()
 
   if (live) {
-    return <LiveCode code={code} language={language} noinline={noinline} metastring={metastring} />
+    return (
+      <LiveCode code={code} highlight={highlight} language={language} noinline={noinline} metastring={metastring} />
+    )
   }
 
   return (


### PR DESCRIPTION
In order to emphasize a particular range of lines, this adds the `highlight` attribute on the live code blocks. The line highlighting will disappear when the live example is edited.

This implementation is quite simple, and we could improve on this to support highlighting multiple ranges in the future.

The approach is a bit unorthodox, as `react-live` [does not support line highlighting](https://github.com/FormidableLabs/react-live/issues/87) yet.

![Example with line highlighting enabled on a code block](https://user-images.githubusercontent.com/24622853/179027761-42cbab3a-affe-41d0-a392-638b4d0735e7.png)


