### PR TITLE
Update peer dependencies to use ">" greater than

### DIFF
--- a/.changeset/four-donuts-fly.md
+++ b/.changeset/four-donuts-fly.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Making peer dependencies less strict with ">" to supress errors with npm v7+

--- a/theme/package.json
+++ b/theme/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^16.13.1"
   },
   "peerDependencies": {
-    "gatsby": "2.x",
+    "gatsby": ">2",
     "react": "^16.9.x",
     "react-dom": "^16.9.x"
   },

--- a/theme/package.json
+++ b/theme/package.json
@@ -24,8 +24,8 @@
   },
   "peerDependencies": {
     "gatsby": ">2",
-    "react": "^16.9.x",
-    "react-dom": "^16.9.x"
+    "react": ">16.9.x",
+    "react-dom": ">16.9.x"
   },
   "dependencies": {
     "@babel/preset-env": "^7.5.5",


### PR DESCRIPTION
Making peer dependencies less strict because with npm v7+ unmatched peer dependencies throw an error.

_Not sure if this is a good idea? Will this lead to more dependency bugs that are harder to track?_

Update: It's a bad idea 😓 It's not enough to update peer dependencies, we'll have to update all the plugins to their compatible versions as well :(