### PR TITLE
Add a11yReviewed frontmatter data to static files

### DIFF
--- a/.changeset/lemon-pants-mate.md
+++ b/.changeset/lemon-pants-mate.md
@@ -2,5 +2,4 @@
 '@primer/gatsby-theme-doctocat': patch
 ---
 
-- Add accessible frontmatter data to onPostBuild static files
-- Add accessible label in the Layout component
+- Add a11yReviewed frontmatter data to onPostBuild static files

--- a/.changeset/lemon-pants-mate.md
+++ b/.changeset/lemon-pants-mate.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+Add accessible frontmatter data to onPostBuild static files

--- a/.changeset/lemon-pants-mate.md
+++ b/.changeset/lemon-pants-mate.md
@@ -2,4 +2,5 @@
 '@primer/gatsby-theme-doctocat': patch
 ---
 
-Add accessible frontmatter data to onPostBuild static files
+- Add accessible frontmatter data to onPostBuild static files
+- Add accessible label in the Layout component

--- a/docs/content/components/do-dont.mdx
+++ b/docs/content/components/do-dont.mdx
@@ -53,7 +53,8 @@ The `DoDontContainer` component also accepts a `stacked` prop to create stacked 
 ```jsx live
 <DoDontContainer stacked>
   <Do indented>
-    Place pane regions on the left to display navigation, filtering, or an overview for entities such as users, bots, apps, etc.
+    Place pane regions on the left to display navigation, filtering, or an
+    overview for entities such as users, bots, apps, etc.
   </Do>
   <Dont indented>
     Don't display more than three columns of information on a page.

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -86,6 +86,7 @@ exports.onPostBuild = async ({graphql}) => {
               frontmatter {
                 componentId
                 status
+                accessible
               }
             }
           }
@@ -97,7 +98,8 @@ exports.onPostBuild = async ({graphql}) => {
       return {
         id: node.context.frontmatter.componentId,
         path: node.path,
-        status: node.context.frontmatter.status.toLowerCase()
+        status: node.context.frontmatter.status.toLowerCase(),
+        accessible: node.context.frontmatter.accessible || false
       }
     })
 

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -86,7 +86,7 @@ exports.onPostBuild = async ({graphql}) => {
               frontmatter {
                 componentId
                 status
-                accessible
+                a11yReviewed
               }
             }
           }
@@ -99,7 +99,7 @@ exports.onPostBuild = async ({graphql}) => {
         id: node.context.frontmatter.componentId,
         path: node.path,
         status: node.context.frontmatter.status.toLowerCase(),
-        accessible: node.context.frontmatter.accessible || false
+        a11yReviewed: node.context.frontmatter.a11yReviewed || false
       }
     })
 

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,5 +1,5 @@
 import componentMetadata from '@primer/component-metadata'
-import {Box, Heading, Text} from '@primer/react'
+import {Box, Heading, Text, LabelGroup, Label} from '@primer/react'
 import React from 'react'
 import Head from './head'
 import Header, {HEADER_HEIGHT} from './header'
@@ -12,7 +12,7 @@ import FigmaLink from './figma-link'
 import TableOfContents from './table-of-contents'
 
 function Layout({children, pageContext}) {
-  let {title, description, figma, status, source, storybook, additionalContributors, componentId} =
+  let {title, description, figma, status, accessible, source, storybook, additionalContributors, componentId} =
     pageContext.frontmatter
 
   if (!additionalContributors) {
@@ -70,7 +70,16 @@ function Layout({children, pageContext}) {
                 <Heading as="h1" sx={{mr: 2}}>
                   {title}
                 </Heading>{' '}
-                {status ? <StatusLabel status={status} /> : null}
+                {status || accessible ? (
+                  <LabelGroup>
+                    {status ? <StatusLabel status={status} /> : null}
+                    {accessible ? (
+                      <Label sx={{backgroundColor: 'accent.emphasis', color: 'fg.onEmphasis'}} variant="accent">
+                        Accessible
+                      </Label>
+                    ) : null}
+                  </LabelGroup>
+                ) : null}
               </Box>
               {description ? <Box sx={{fontSize: 3, pb: 2}}>{description}</Box> : null}
               {source || storybook ? (

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,5 +1,5 @@
 import componentMetadata from '@primer/component-metadata'
-import {Box, Heading, Text, LabelGroup, Label} from '@primer/react'
+import {Box, Heading, Text} from '@primer/react'
 import React from 'react'
 import Head from './head'
 import Header, {HEADER_HEIGHT} from './header'
@@ -12,7 +12,7 @@ import FigmaLink from './figma-link'
 import TableOfContents from './table-of-contents'
 
 function Layout({children, pageContext}) {
-  let {title, description, figma, status, accessible, source, storybook, additionalContributors, componentId} =
+  let {title, description, figma, status, source, storybook, additionalContributors, componentId} =
     pageContext.frontmatter
 
   if (!additionalContributors) {
@@ -70,16 +70,7 @@ function Layout({children, pageContext}) {
                 <Heading as="h1" sx={{mr: 2}}>
                   {title}
                 </Heading>{' '}
-                {status || accessible ? (
-                  <LabelGroup>
-                    {status ? <StatusLabel status={status} /> : null}
-                    {accessible ? (
-                      <Label sx={{backgroundColor: 'accent.emphasis', color: 'fg.onEmphasis'}} variant="accent">
-                        Accessible
-                      </Label>
-                    ) : null}
-                  </LabelGroup>
-                ) : null}
+                {status ? <StatusLabel status={status} /> : null}
               </Box>
               {description ? <Box sx={{fontSize: 3, pb: 2}}>{description}</Box> : null}
               {source || storybook ? (


### PR DESCRIPTION
Add the `a11yReviewed` boolean data to the components.json static files generated onPostBuild.

<img width="626" alt="Screenshot 2022-08-23 at 12 46 13" src="https://user-images.githubusercontent.com/912236/186139317-70228769-4fcb-4a4c-9a1d-c35cca01d924.png">


### Next steps
- Add the frontmatter `a11yReviewed` variable to flag accessible components in PVC and PRC
- Use the generated `components.json` files to add an accessible `Label` component in the `primer.style/status` section

### Related 
- https://github.com/github/primer/issues/1212

