### PR TITLE
Footnotes, Table and StatusLabel styles

### DIFF
--- a/.changeset/brown-cobras-buy.md
+++ b/.changeset/brown-cobras-buy.md
@@ -1,0 +1,8 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+- Ad superscript component
+- Basic style for footnotes section
+- Table styles
+- Add sizes prop to StatusLabel component

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -4,17 +4,8 @@ status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
 componentId: caption
 ---
-import {StatusLabel} from '@primer/gatsby-theme-doctocat'
 
-
-The caption component[^1] can be used[^2] to append a caption[^3] to images used[^4] in documentation.
-
-[^1]: The caption component is not yet available in Primer CSS.
-[^2]: Random text to test the footnotes section.
-[^3]: Random text to test the caption component.
-[^4]: Lorem ipsum dolor [sit amet](https://mdxjs.com/blog/shortcodes), consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-
-
+The caption component can be used to append a caption to images used in documentation.
 
 ## Usage
 

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -4,6 +4,8 @@ status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
 componentId: caption
 ---
+import {StatusLabel} from '@primer/gatsby-theme-doctocat'
+
 
 The caption component[^1] can be used[^2] to append a caption[^3] to images used[^4] in documentation.
 
@@ -12,18 +14,7 @@ The caption component[^1] can be used[^2] to append a caption[^3] to images used
 [^3]: Random text to test the caption component.
 [^4]: Lorem ipsum dolor [sit amet](https://mdxjs.com/blog/shortcodes), consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
-| Column 1 | Column 2 | Column 3 | Column 4 |
-| -------- | -------- | -------- | -------- |
-| header 1 | header 2 | header 3 | header 4 |
-| row 1 | row 2 | row 3 | row 4 |
-| header 1 | header 2 | header 3 | header 4 |
-| row 1 | row 2 | row 3 | row 4 |
-| header 1 | header 2 | header 3 | header 4 |
-| row 1 | row 2 | row 3 | row 4 |
-| header 1 | header 2 | header 3 | header 4 |
-| row 1 | row 2 | row 3 | row 4 |
-| header 1 | header 2 | header 3 | header 4 |
-| row 1 | row 2 | row 3 | row 4 |
+
 
 ## Usage
 

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -5,7 +5,9 @@ source: https://github.com/primer/doctocat/blob/master/theme/src/components/capt
 componentId: caption
 ---
 
-The caption component can be used to append a caption to images used in documentation.
+The caption component[^1] can be used to append a caption to images used in documentation.
+
+[^1]: The caption component is not yet available in Primer CSS.
 
 ## Usage
 

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -12,6 +12,19 @@ The caption component[^1] can be used[^2] to append a caption[^3] to images used
 [^3]: Random text to test the caption component.
 [^4]: Lorem ipsum dolor [sit amet](https://mdxjs.com/blog/shortcodes), consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
+| Column 1 | Column 2 | Column 3 | Column 4 |
+| -------- | -------- | -------- | -------- |
+| header 1 | header 2 | header 3 | header 4 |
+| row 1 | row 2 | row 3 | row 4 |
+| header 1 | header 2 | header 3 | header 4 |
+| row 1 | row 2 | row 3 | row 4 |
+| header 1 | header 2 | header 3 | header 4 |
+| row 1 | row 2 | row 3 | row 4 |
+| header 1 | header 2 | header 3 | header 4 |
+| row 1 | row 2 | row 3 | row 4 |
+| header 1 | header 2 | header 3 | header 4 |
+| row 1 | row 2 | row 3 | row 4 |
+
 ## Usage
 
 `Caption` is a [shortcode](https://mdxjs.com/blog/shortcodes), meaning it's globally available in all `.md` and `.mdx` files. So you can use the `Caption` component in any `.md` or `.mdx` file without importing it.

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -5,9 +5,12 @@ source: https://github.com/primer/doctocat/blob/master/theme/src/components/capt
 componentId: caption
 ---
 
-The caption component[^1] can be used to append a caption to images used in documentation.
+The caption component[^1] can be used[^2] to append a caption[^3] to images used[^4] in documentation.
 
 [^1]: The caption component is not yet available in Primer CSS.
+[^2]: Random text to test the footnotes section.
+[^3]: Random text to test the caption component.
+[^4]: Lorem ipsum dolor [sit amet](https://mdxjs.com/blog/shortcodes), consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
 ## Usage
 

--- a/theme/src/components/horizontal-rule.js
+++ b/theme/src/components/horizontal-rule.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import themeGet from '@styled-system/theme-get'
 
 const HorizontalRule = styled.hr`
-  height: ${themeGet('space.1')};
+  height: 1px;
   padding: 0;
   margin: ${themeGet('space.4')} 0;
   background-color: ${themeGet('colors.border.default')};

--- a/theme/src/components/horizontal-rule.js
+++ b/theme/src/components/horizontal-rule.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import themeGet from '@styled-system/theme-get'
 
 const HorizontalRule = styled.hr`
-  height: 1px;
+  height: ${themeGet('borderWidths.1')};
   padding: 0;
   margin: ${themeGet('space.4')} 0;
   background-color: ${themeGet('colors.border.default')};

--- a/theme/src/components/horizontal-rule.js
+++ b/theme/src/components/horizontal-rule.js
@@ -5,7 +5,7 @@ const HorizontalRule = styled.hr`
   height: ${themeGet('space.1')};
   padding: 0;
   margin: ${themeGet('space.4')} 0;
-  background-color: ${themeGet('colors.gray.2')};
+  background-color: ${themeGet('colors.border.default')};
   border: 0;
 `
 

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -100,7 +100,7 @@ function Layout({children, pageContext}) {
               >
                 {status ? (
                   <Box as={'ul'} sx={{display: 'flex', gap: 1, alignItems: 'center', m: 0, p: 0, paddingInline: 0}}>
-                    <StatusLabel status={status} />
+                    <StatusLabel siz="large" status={status} />
                     {a11yReviewed ? (
                       <Label
                         as={'li'}

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -100,7 +100,7 @@ function Layout({children, pageContext}) {
               >
                 {status ? (
                   <Box as={'ul'} sx={{display: 'flex', gap: 1, alignItems: 'center', m: 0, p: 0, paddingInline: 0}}>
-                    <StatusLabel siz="large" status={status} />
+                    <StatusLabel size="large" status={status} />
                     {a11yReviewed ? (
                       <Label
                         as={'li'}

--- a/theme/src/components/status-label.js
+++ b/theme/src/components/status-label.js
@@ -23,13 +23,15 @@ function getStatusBackgroundColor(status) {
   return STATUS_BACKGROUND[status.toLowerCase()] || 'neutral.subtle'
 }
 
-function StatusLabel({status}) {
+function StatusLabel({status, size}) {
+  const circleSize = size === 'large' ? 8 : 6
+
   return (
     <Label
       as={'li'}
-      size="large"
+      size={size || 'small'}
       sx={{
-        display: 'flex',
+        display: 'inline-flex',
         alignItems: 'center',
         gap: 1,
         backgroundColor: getStatusBackgroundColor(status),
@@ -37,7 +39,10 @@ function StatusLabel({status}) {
         fontWeight: 'normal'
       }}
     >
-      <Box aria-hidden="true" sx={{height: 8, width: 8, backgroundColor: getStatusColor(status), borderRadius: 99}} />
+      <Box
+        aria-hidden="true"
+        sx={{height: circleSize, width: circleSize, backgroundColor: getStatusColor(status), borderRadius: 99}}
+      />
       {status}
     </Label>
   )

--- a/theme/src/components/superscript.js
+++ b/theme/src/components/superscript.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import {HEADER_HEIGHT} from './header'
 
 const Superscript = styled.sup`
   font-size: 75%;
@@ -6,6 +7,7 @@ const Superscript = styled.sup`
   position: relative;
   vertical-align: baseline;
   top: -0.5em;
+  scroll-margin-top: ${HEADER_HEIGHT + 24}px;
 
   a {
     text-decoration: none;

--- a/theme/src/components/superscript.js
+++ b/theme/src/components/superscript.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+
+const Superscript = styled.sup`
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+  top: -0.5em;
+
+  a {
+    text-decoration: none;
+
+    ::before {
+      content: '[';
+    }
+
+    ::after {
+      content: ']';
+    }
+  }
+`
+
+export default Superscript

--- a/theme/src/components/table.js
+++ b/theme/src/components/table.js
@@ -2,28 +2,47 @@ import styled from 'styled-components'
 import themeGet from '@styled-system/theme-get'
 
 const Table = styled.table`
-  display: block;
   width: 100%;
   margin: 0 0 ${themeGet('space.3')};
   overflow: auto;
+  border-collapse: separate;
+  border-spacing: 0px;
 
   th {
     font-weight: ${themeGet('fontWeights.bold')};
+    background-color: ${themeGet('colors.neutral.subtle')};
   }
 
   th,
   td {
     padding: ${themeGet('space.2')} ${themeGet('space.3')};
-    border: 1px solid ${themeGet('colors.border.muted')};
+    border-left: 1px solid ${themeGet('colors.border.muted')};
+    border-top: 1px solid ${themeGet('colors.border.muted')};
   }
 
-  tr {
-    background-color: ${themeGet('colors.white')};
-    border-top: 1px solid ${themeGet('colors.border.muted')};
+  tr:last-child td {
+    border-bottom: 1px solid ${themeGet('colors.border.muted')};
+  }
 
-    &:nth-child(2n) {
-      background-color: ${themeGet('colors.neutral.subtle')};
-    }
+  tr td:last-child,
+  tr th:last-child {
+    border-right: 1px solid ${themeGet('colors.border.muted')};
+  }
+
+  thead th:first-child {
+    border-top-left-radius: 6px;
+  }
+
+  thead th:last-child {
+    border-top-right-radius: 6px;
+  }
+
+  tbody tr:last-child td:last-child {
+    border-bottom-right-radius: 6px;
+  }
+
+  tbody tr:last-child td:first-child {
+    border-bottom-left-radius: 6px;
   }
 
   img {

--- a/theme/src/components/table.js
+++ b/theme/src/components/table.js
@@ -16,17 +16,20 @@ const Table = styled.table`
   th,
   td {
     padding: ${themeGet('space.2')} ${themeGet('space.3')};
-    border-left: 1px solid ${themeGet('colors.border.muted')};
-    border-top: 1px solid ${themeGet('colors.border.muted')};
+    border-color: ${themeGet('colors.border.muted')};
+    border-style: solid;
+    border-width: 0;
+    border-left-width: ${themeGet('borderWidths.1')};
+    border-top-width: ${themeGet('borderWidths.1')};
   }
 
   tr:last-child td {
-    border-bottom: 1px solid ${themeGet('colors.border.muted')};
+    border-bottom-width: ${themeGet('borderWidths.1')};
   }
 
   tr td:last-child,
   tr th:last-child {
-    border-right: 1px solid ${themeGet('colors.border.muted')};
+    border-right-width: ${themeGet('borderWidths.1')};
   }
 
   thead th:first-child {

--- a/theme/src/components/table.js
+++ b/theme/src/components/table.js
@@ -30,19 +30,19 @@ const Table = styled.table`
   }
 
   thead th:first-child {
-    border-top-left-radius: 6px;
+    border-top-left-radius: ${themeGet('radii.2')};
   }
 
   thead th:last-child {
-    border-top-right-radius: 6px;
+    border-top-right-radius: ${themeGet('radii.2')};
   }
 
   tbody tr:last-child td:last-child {
-    border-bottom-right-radius: 6px;
+    border-bottom-right-radius: ${themeGet('radii.2')};
   }
 
   tbody tr:last-child td:first-child {
-    border-bottom-left-radius: 6px;
+    border-bottom-left-radius: ${themeGet('radii.2')};
   }
 
   img {

--- a/theme/src/components/wrap-page-element.js
+++ b/theme/src/components/wrap-page-element.js
@@ -8,6 +8,21 @@ const GlobalStyles = createGlobalStyle`
     color: ${themeGet('colors.fg.default')};
     background-color: ${themeGet('colors.canvas.default')};
   }
+
+  .footnotes {
+    font-size: ${themeGet('fontSizes.1')};
+    color: ${themeGet('colors.fg.subtle')};
+
+    ol {
+      padding-left: ${themeGet('space.3')};
+    }
+
+    a {
+      font-family: ${themeGet('fonts.mono')};
+      margin-left: 2px;
+      text-decoration: none;
+    }
+  }
 `
 
 function wrapPageElement({element}) {

--- a/theme/src/components/wrap-page-element.js
+++ b/theme/src/components/wrap-page-element.js
@@ -17,7 +17,7 @@ const GlobalStyles = createGlobalStyle`
       padding-left: ${themeGet('space.3')};
     }
 
-    a {
+  .footnote-backref {
       font-family: ${themeGet('fonts.mono')};
       margin-left: 2px;
       text-decoration: none;

--- a/theme/src/components/wrap-root-element.js
+++ b/theme/src/components/wrap-root-element.js
@@ -16,6 +16,7 @@ import InlineCode from './inline-code'
 import List from './list'
 import Note from './note'
 import Paragraph from './paragraph'
+import Superscript from './superscript'
 import Table from './table'
 
 const components = {
@@ -28,6 +29,7 @@ const components = {
   p: Paragraph,
   hr: HorizontalRule,
   blockquote: Blockquote,
+  sup: Superscript,
   h1: H1,
   h2: H2,
   h3: H3,


### PR DESCRIPTION
- [x] Adjust `hr` background color
- [x] Ad `superscript` component
- [x] Footnotes styling. 
- [x] Table styles
- [x] Add sizes prop to `StatusLabel` component. Default to `small` size as well as the `Label` component for better usage within tables (Status table and PRC/PVC statuses pages).

#### Superscript and Footnotes
Add support and basic styles to support superscripts and footnotes. Aligned them to all [Markdown fields in dotcom](https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/)

<img width="1051" alt="Screenshot 2022-10-04 at 14 59 09" src="https://user-images.githubusercontent.com/912236/193825412-49554f68-6b52-4643-bb3a-6864198cc973.png">


#### Tables
Removed the zebra stripped cells, add functional subtle background on the header, a 🍕  border-radius and use full-width space.

<img width="1012" alt="Screenshot 2022-10-04 at 14 49 11" src="https://user-images.githubusercontent.com/912236/193824839-a53b7d8f-6359-4305-a8cd-df05e0cc858f.png">

#### StatusLabel
Add `size` prop to adjust its usage to tables

<img width="1102" alt="Screenshot 2022-10-04 at 15 15 02" src="https://user-images.githubusercontent.com/912236/193828791-5ff3c483-5282-4a0c-8ee8-c0dfe0080c7e.png">




