### PR TITLE
Adjust accessibility labels

### DIFF
--- a/.changeset/heavy-apples-relate.md
+++ b/.changeset/heavy-apples-relate.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+Adjust accessibilty labels content

--- a/docs/content/components/caption.mdx
+++ b/docs/content/components/caption.mdx
@@ -3,6 +3,8 @@ title: Caption
 status: New
 source: https://github.com/primer/doctocat/blob/master/theme/src/components/caption.js
 componentId: caption
+a11yReviewed: true
+description: A caption component for images and other media content with a light gray background and a small font size for additional information.
 ---
 
 The caption component can be used to append a caption to images used in documentation.

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -81,11 +81,9 @@ function Layout({children, pageContext}) {
             </Box>
           ) : null}
           <Box sx={{width: '100%', maxWidth: '960px'}}>
-            <Box sx={{mb: 7}}>
+            <Box sx={{mb: 4}}>
               <Box sx={{alignItems: 'center', display: 'flex'}}>
-                <Heading as="h1" sx={{mb: 2}}>
-                  {title}
-                </Heading>{' '}
+                <Heading as="h1">{title}</Heading>{' '}
               </Box>
               {description ? <Box sx={{fontSize: 3, mb: 3}}>{description}</Box> : null}
               <Box
@@ -93,6 +91,8 @@ function Layout({children, pageContext}) {
                   display: 'flex',
                   flexWrap: 'wrap',
                   columnGap: 3,
+                  mb: 7,
+                  mt: 2,
                   rowGap: 3,
                   alignItems: 'center',
                   fontSize: 1

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -115,7 +115,7 @@ function Layout({children, pageContext}) {
                         }}
                       >
                         <StyledOcticon icon={AccessibilityInsetIcon} sx={{fill: 'done.fg'}} />
-                        Reviewed by accessibility team
+                        Reviewed for accessibility
                       </Label>
                     ) : (
                       <Label
@@ -127,7 +127,7 @@ function Layout({children, pageContext}) {
                           borderColor: 'transparent'
                         }}
                       >
-                        Review pending by accessibility team
+                        Not reviewed for accessibility
                       </Label>
                     )}
                   </Box>


### PR DESCRIPTION
- [x] Adjust accessibility label on component pages to `Reviewed for accessibility`, and `Not reviewed for Accessibility`. More info in slack thread: https://github.slack.com/archives/GACAW0NPM/p1665775154710039?thread_ts=1665758162.979459&cid=GACAW0NPM
- [x] Adjust spacing when there are no status labels.

<img width="498" alt="Screenshot 2022-10-21 at 13 08 17" src="https://user-images.githubusercontent.com/912236/197182379-327c0713-6453-45b1-bcb1-72acd59c8b8e.png">



