### PR TITLE
Support two levels of nesting in nav.yml

### DIFF
--- a/.changeset/young-cobras-battle.md
+++ b/.changeset/young-cobras-battle.md
@@ -2,7 +2,7 @@
 "@primer/gatsby-theme-doctocat": minor
 ---
 
-Add support for three levels of nesting in `nav.yml`:
+Add support for two levels of nesting in `nav.yml`:
 
 ```diff
   - title: Introduction

--- a/docs/content/usage/customization.mdx
+++ b/docs/content/usage/customization.mdx
@@ -22,7 +22,7 @@ module.exports = {
     header: {
       title: 'Primer',
       url: 'https://primer.style',
-      logoUrl: 'https://primer.style'
+      logoUrl: 'https://primer.style',
     },
     // Used for SEO
     description: 'My site description',
@@ -46,7 +46,9 @@ Side navigation for your site is generated from the content in `src/@primer/gats
 
 Entries with `children` cannot also have a `url`.
 
-<Note variant="warning">Doctocat only supports one level of nesting. </Note>
+<Note variant="warning">
+  Doctocat supports a maximum of two levels of nesting.
+</Note>
 
 ## Repository
 

--- a/theme/src/components/nav-items.js
+++ b/theme/src/components/nav-items.js
@@ -37,6 +37,15 @@ function NavItems({items}) {
               {item.children.map(child => (
                 <NavItem key={child.title} href={child.url}>
                   {child.title}
+                  {child.children ? (
+                    <NavList.SubNav>
+                      {child.children.map(subChild => (
+                        <NavItem key={subChild.title} href={subChild.url}>
+                          {subChild.title}
+                        </NavItem>
+                      ))}
+                    </NavList.SubNav>
+                  ) : null}
                 </NavItem>
               ))}
             </NavList.Group>


### PR DESCRIPTION
Adds support for two levels of nesting in `nav.yml`:

```diff
  - title: Introduction
    children:
      - title: Getting started
-       url: /getting-started
+       children:
+         - title: React
+           url: /getting-started/react
```

Note: Items with `children` cannot also have URLs.