### PR TITLE
Remove news

### DIFF
--- a/.changeset/proud-horses-know.md
+++ b/.changeset/proud-horses-know.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': minor
+---
+
+Remove news from the menu

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -1,5 +1,3 @@
-- title: What's new
-  url: https://primer.style/news
 - title: Design
   children:
     - title: Interface guidelines


### PR DESCRIPTION
As part of https://github.com/primer/primer.style/pull/354 we're removing news.