### PR TITLE
Remove Command line

### DIFF
--- a/.changeset/tricky-toys-unite.md
+++ b/.changeset/tricky-toys-unite.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Remove `Command line` from the `Design` menu since it's now merged in guidelines.

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -6,8 +6,6 @@
       url: https://primer.style/octicons
     - title: Presentations
       url: https://primer.style/presentations
-    - title: Command line
-      url: https://primer.style/cli
     - title: Mobile
       url: https://primer.style/mobile
     - title: Desktop


### PR DESCRIPTION
Merge after: https://github.com/primer/design/pull/376

As part of https://github.com/primer/design/pull/376 we're merging the Command Line within the design docs.