### PR TITLE
Remove `mobile` from the menu

### DIFF
--- a/.changeset/two-pumpkins-trade.md
+++ b/.changeset/two-pumpkins-trade.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Remove `Mobile` from the `Design` menu since it's now merged in our guidelines.

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -6,8 +6,6 @@
       url: https://primer.style/octicons
     - title: Presentations
       url: https://primer.style/presentations
-    - title: Mobile
-      url: https://primer.style/mobile
     - title: Desktop
       url: https://primer.style/desktop
 - title: Build


### PR DESCRIPTION
Following merging https://github.com/primer/design/pull/379

We can remove the mobile menu item as it's part of our design guidelines now.