### PR TITLE
Update primer-nav.yml

### DIFF
--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -3,11 +3,9 @@
     - title: Interface guidelines
       url: https://primer.style/design
     - title: Octicons
-      url: https://primer.style/octicons
-    - title: Presentations
-      url: https://primer.style/presentations
+      url: https://primer.style/design/foundations/icons
     - title: Desktop
-      url: https://primer.style/desktop
+      url: https://primer.style/design/native/desktop
 - title: Build
   children:
     - title: CSS
@@ -19,6 +17,6 @@
     - title: ViewComponents
       url: https://primer.style/view-components
 - title: Contribute
-  url: https://primer.style/contribute
+  url: https://primer.style/design/guides/contribute
 - title: About
-  url: https://primer.style/team
+  url: https://primer.style/design/guides/about

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -6,6 +6,10 @@
       url: https://primer.style/design/foundations/icons
     - title: Desktop
       url: https://primer.style/design/native/desktop
+    - title: Mobile
+      url: https://primer.style/design/native/mobile
+    - title: CLI
+      url: https://primer.style/design/native/cli
 - title: Build
   children:
     - title: CSS


### PR DESCRIPTION
This directs the links in the nav to the right place in /design, if it exists. It allows us to begin to deprecate the surrounding sites that are no longer being maintained, such as primer.style/contribute.