### PR TITLE
Move heading permalinks to after headings

### DIFF
--- a/.changeset/hungry-ads-grab.md
+++ b/.changeset/hungry-ads-grab.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+Move heading permalinks to after headings

--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -29,18 +29,19 @@ function MarkdownHeading({children, ...props}) {
 
   return (
     <StyledHeading id={id} {...props}>
+      {children}
       <Link
         href={`#${id}`}
         aria-label={`${text} permalink`}
         sx={{
+          display: 'inline-flex',
           p: 2,
-          ml: -32,
-          color: 'fg.default'
+          ml: 1,
+          color: 'fg.muted'
         }}
       >
         <LinkIcon className="octicon-link" verticalAlign="middle" />
       </Link>
-      {children}
     </StyledHeading>
   )
 }

--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -11,14 +11,17 @@ const StyledHeading = styled(Heading)`
   margin-top: ${themeGet('space.4')};
   margin-bottom: ${themeGet('space.3')};
   scroll-margin-top: ${HEADER_HEIGHT + 24}px;
+  line-height: ${themeGet('lineHeights.condensed')};
 
-  & .octicon-link {
-    visibility: hidden;
-  }
+  @media (hover: hover) {
+    & .octicon-link {
+      visibility: hidden;
+    }
 
-  &:hover .octicon-link,
-  &:focus-within .octicon-link {
-    visibility: visible;
+    &:hover .octicon-link,
+    &:focus-within .octicon-link {
+      visibility: visible;
+    }
   }
 `
 
@@ -55,13 +58,13 @@ function MarkdownHeading({children, ...props}) {
 }
 
 const StyledH1 = styled(StyledHeading).attrs({as: 'h1'})`
-  padding-bottom: ${themeGet('space.1')};
+  padding-bottom: ${themeGet('space.2')};
   font-size: ${themeGet('fontSizes.5')};
   border-bottom: 1px solid ${themeGet('colors.border.default')};
 `
 
 const StyledH2 = styled(StyledHeading).attrs({as: 'h2'})`
-  padding-bottom: ${themeGet('space.1')};
+  padding-bottom: ${themeGet('space.2')};
   font-size: ${themeGet('fontSizes.4')};
   border-bottom: 1px solid ${themeGet('colors.border.default')};
 `

--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -1,4 +1,4 @@
-import {Heading, Link} from '@primer/react'
+import {Heading, Link, StyledOcticon} from '@primer/react'
 import {LinkIcon} from '@primer/octicons-react'
 import themeGet from '@styled-system/theme-get'
 import GithubSlugger from 'github-slugger'
@@ -29,18 +29,26 @@ function MarkdownHeading({children, ...props}) {
 
   return (
     <StyledHeading id={id} {...props}>
-      {children}
       <Link
         href={`#${id}`}
-        aria-label={`${text} permalink`}
         sx={{
-          display: 'inline-flex',
-          p: 2,
-          ml: 1,
-          color: 'fg.muted'
+          color: 'inherit',
+          '&:hover, &:focus': {
+            textDecoration: 'none'
+          }
         }}
       >
-        <LinkIcon className="octicon-link" verticalAlign="middle" />
+        {children}
+        <StyledOcticon
+          icon={LinkIcon}
+          className="octicon-link"
+          sx={{
+            ml: 2,
+            color: 'fg.muted',
+            // !important is needed here to override default icon styles
+            verticalAlign: 'middle !important'
+          }}
+        />
       </Link>
     </StyledHeading>
   )


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1856

## Before

<img width="308" alt="CleanShot 2023-03-13 at 14 23 19@2x" src="https://user-images.githubusercontent.com/4608155/224823800-1b70a366-6995-4bc9-8b49-8f8840c88df3.png">


## After

<img width="370" alt="CleanShot 2023-03-13 at 14 22 41@2x" src="https://user-images.githubusercontent.com/4608155/224823697-340c068e-e612-4fd5-92cd-c464f99084e0.png">
