### PR TITLE
fix a couple of accessibility issues

### DIFF
--- a/.changeset/young-cheetahs-sell.md
+++ b/.changeset/young-cheetahs-sell.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+Accessibility improvements

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -43,7 +43,6 @@ function Header({isSearchEnabled}) {
             >
               <StyledOcticon icon={MarkGithubIcon} size="medium" />
             </Link>
-            <Box sx={{fontSize: 'unset', fontWeight: 'unset', m: 0, display: 'flex', alignItems: 'center'}}>
               {siteMetadata.header.title ? (
                 <Link
                   href={siteMetadata.header.url}
@@ -88,7 +87,6 @@ function Header({isSearchEnabled}) {
                   </Link>
                 </>
               ) : null}
-            </Box>
 
             {isSearchEnabled ? (
               <Box sx={{display: ['none', null, null, 'block'], ml: 4}}>

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -8,6 +8,7 @@ import MobileSearch from './mobile-search'
 import NavDrawer, {useNavDrawerState} from './nav-drawer'
 import NavDropdown, {NavDropdownItem} from './nav-dropdown'
 import Search from './search'
+import SkipLink from './skip-link'
 
 export const HEADER_HEIGHT = 66
 
@@ -21,7 +22,6 @@ function Header({isSearchEnabled}) {
       <Box sx={{position: 'sticky', top: 0, zIndex: 1}}>
         <Box
           as="header"
-          aria-labelledby="site-heading"
           sx={{
             display: 'flex',
             height: HEADER_HEIGHT,
@@ -31,6 +31,7 @@ function Header({isSearchEnabled}) {
             bg: 'canvas.default'
           }}
         >
+          <SkipLink />
           <Box sx={{display: 'flex', alignItems: 'center'}}>
             <Link
               href={siteMetadata.header.logoUrl}
@@ -43,8 +44,6 @@ function Header({isSearchEnabled}) {
               <StyledOcticon icon={MarkGithubIcon} size="medium" />
             </Link>
             <Box
-              as="h2"
-              id="site-heading"
               sx={{fontSize: 'unset', fontWeight: 'unset', m: 0, display: 'flex', alignItems: 'center'}}
             >
               {siteMetadata.header.title ? (

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -43,9 +43,7 @@ function Header({isSearchEnabled}) {
             >
               <StyledOcticon icon={MarkGithubIcon} size="medium" />
             </Link>
-            <Box
-              sx={{fontSize: 'unset', fontWeight: 'unset', m: 0, display: 'flex', alignItems: 'center'}}
-            >
+            <Box sx={{fontSize: 'unset', fontWeight: 'unset', m: 0, display: 'flex', alignItems: 'center'}}>
               {siteMetadata.header.title ? (
                 <Link
                   href={siteMetadata.header.url}

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -43,50 +43,50 @@ function Header({isSearchEnabled}) {
             >
               <StyledOcticon icon={MarkGithubIcon} size="medium" />
             </Link>
-              {siteMetadata.header.title ? (
-                <Link
-                  href={siteMetadata.header.url}
-                  sx={{
-                    color: 'accent.fg',
-                    fontFamily: 'mono',
-                    display: [
-                      // We only hide "Primer" on small viewports if a shortName is defined.
-                      siteMetadata.shortName ? 'none' : 'inline-block',
-                      null,
-                      null,
-                      'inline-block'
-                    ]
-                  }}
-                >
-                  {siteMetadata.header.title}
-                </Link>
-              ) : null}
-              {siteMetadata.shortName ? (
-                <>
-                  {siteMetadata.header.title && (
-                    <Text
-                      sx={{
-                        display: ['none', null, null, 'inline-block'],
-                        color: 'accent.fg',
-                        fontFamily: 'mono',
-                        mx: 2
-                      }}
-                    >
-                      /
-                    </Text>
-                  )}
-                  <Link
-                    as={GatsbyLink}
-                    to="/"
+            {siteMetadata.header.title ? (
+              <Link
+                href={siteMetadata.header.url}
+                sx={{
+                  color: 'accent.fg',
+                  fontFamily: 'mono',
+                  display: [
+                    // We only hide "Primer" on small viewports if a shortName is defined.
+                    siteMetadata.shortName ? 'none' : 'inline-block',
+                    null,
+                    null,
+                    'inline-block'
+                  ]
+                }}
+              >
+                {siteMetadata.header.title}
+              </Link>
+            ) : null}
+            {siteMetadata.shortName ? (
+              <>
+                {siteMetadata.header.title && (
+                  <Text
                     sx={{
+                      display: ['none', null, null, 'inline-block'],
                       color: 'accent.fg',
-                      fontFamily: 'mono'
+                      fontFamily: 'mono',
+                      mx: 2
                     }}
                   >
-                    {siteMetadata.shortName}
-                  </Link>
-                </>
-              ) : null}
+                    /
+                  </Text>
+                )}
+                <Link
+                  as={GatsbyLink}
+                  to="/"
+                  sx={{
+                    color: 'accent.fg',
+                    fontFamily: 'mono'
+                  }}
+                >
+                  {siteMetadata.shortName}
+                </Link>
+              </>
+            ) : null}
 
             {isSearchEnabled ? (
               <Box sx={{display: ['none', null, null, 'block'], ml: 4}}>

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,8 +1,8 @@
 import componentMetadata from '@primer/component-metadata'
-import { Box, Heading, Text } from '@primer/react'
+import {Box, Heading, Text} from '@primer/react'
 import React from 'react'
 import Head from './head'
-import Header, { HEADER_HEIGHT } from './header'
+import Header, {HEADER_HEIGHT} from './header'
 import PageFooter from './page-footer'
 import Sidebar from './sidebar'
 import SourceLink from './source-link'
@@ -15,7 +15,7 @@ import StorybookLink from './storybook-link'
 import FigmaLink from './figma-link'
 import TableOfContents from './table-of-contents'
 
-function Layout({ children, pageContext }) {
+function Layout({children, pageContext}) {
   let {
     title,
     description,
@@ -44,11 +44,11 @@ function Layout({ children, pageContext }) {
   }
 
   return (
-    <Box sx={{ flexDirection: 'column', minHeight: '100vh', display: 'flex' }}>
+    <Box sx={{flexDirection: 'column', minHeight: '100vh', display: 'flex'}}>
       <Head title={title} description={description} />
       <Header />
-      <Box css={{ zIndex: 0 }} sx={{ flex: '1 1 auto', flexDirection: 'row', display: 'flex' }}>
-        <Box sx={{ display: ['none', null, null, 'block'] }}>
+      <Box css={{zIndex: 0}} sx={{flex: '1 1 auto', flexDirection: 'row', display: 'flex'}}>
+        <Box sx={{display: ['none', null, null, 'block']}}>
           <Sidebar />
         </Box>
         <Box
@@ -71,22 +71,20 @@ function Layout({ children, pageContext }) {
                 top: HEADER_HEIGHT + 48,
                 maxHeight: `calc(100vh - ${HEADER_HEIGHT}px - 48px)`
               }}
-              css={{ gridArea: 'table-of-contents', overflow: 'auto' }}
+              css={{gridArea: 'table-of-contents', overflow: 'auto'}}
             >
-              <Heading as="h3" sx={{ fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3 }} id="toc-heading">
+              <Heading as="h3" sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
                 On this page
               </Heading>
               <TableOfContents aria-labelledby="toc-heading" items={pageContext.tableOfContents.items} />
             </Box>
           ) : null}
-          <Box
-            sx={{ width: '100%', maxWidth: '960px' }}>
-            <Box as="main"
-              id="skip-nav" sx={{ mb: 4 }}>
-              <Box sx={{ alignItems: 'center', display: 'flex' }}>
+          <Box sx={{width: '100%', maxWidth: '960px'}}>
+            <Box as="main" id="skip-nav" sx={{mb: 4}}>
+              <Box sx={{alignItems: 'center', display: 'flex'}}>
                 <Heading as="h1">{title}</Heading>{' '}
               </Box>
-              {description ? <Box sx={{ fontSize: 3, mb: 3 }}>{description}</Box> : null}
+              {description ? <Box sx={{fontSize: 3, mb: 3}}>{description}</Box> : null}
               <Box
                 sx={{
                   display: 'flex',
@@ -156,14 +154,14 @@ function Layout({ children, pageContext }) {
                   borderRadius: 2
                 }}
               >
-                <Box sx={{ px: 3, py: 2 }}>
+                <Box sx={{px: 3, py: 2}}>
                   <Box
-                    sx={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex' }}
+                    sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
                   >
-                    <Text sx={{ fontWeight: 'bold' }}>On this page</Text>
+                    <Text sx={{fontWeight: 'bold'}}>On this page</Text>
                   </Box>
                 </Box>
-                <Box sx={{ borderTop: '1px solid', borderColor: 'border.muted' }}>
+                <Box sx={{borderTop: '1px solid', borderColor: 'border.muted'}}>
                   <TableOfContents items={pageContext.tableOfContents.items} />
                 </Box>
               </Box>
@@ -171,7 +169,7 @@ function Layout({ children, pageContext }) {
             {children}
             <PageFooter
               editUrl={pageContext.editUrl}
-              contributors={pageContext.contributors.concat(additionalContributors.map(login => ({ login })))}
+              contributors={pageContext.contributors.concat(additionalContributors.map(login => ({login})))}
             />
           </Box>
         </Box>

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,8 +1,8 @@
 import componentMetadata from '@primer/component-metadata'
-import {Box, Heading, Text} from '@primer/react'
+import { Box, Heading, Text } from '@primer/react'
 import React from 'react'
 import Head from './head'
-import Header, {HEADER_HEIGHT} from './header'
+import Header, { HEADER_HEIGHT } from './header'
 import PageFooter from './page-footer'
 import Sidebar from './sidebar'
 import SourceLink from './source-link'
@@ -15,7 +15,7 @@ import StorybookLink from './storybook-link'
 import FigmaLink from './figma-link'
 import TableOfContents from './table-of-contents'
 
-function Layout({children, pageContext}) {
+function Layout({ children, pageContext }) {
   let {
     title,
     description,
@@ -44,16 +44,14 @@ function Layout({children, pageContext}) {
   }
 
   return (
-    <Box sx={{flexDirection: 'column', minHeight: '100vh', display: 'flex'}}>
+    <Box sx={{ flexDirection: 'column', minHeight: '100vh', display: 'flex' }}>
       <Head title={title} description={description} />
       <Header />
-      <Box css={{zIndex: 0}} sx={{flex: '1 1 auto', flexDirection: 'row', display: 'flex'}}>
-        <Box sx={{display: ['none', null, null, 'block']}}>
+      <Box css={{ zIndex: 0 }} sx={{ flex: '1 1 auto', flexDirection: 'row', display: 'flex' }}>
+        <Box sx={{ display: ['none', null, null, 'block'] }}>
           <Sidebar />
         </Box>
         <Box
-          as="main"
-          id="skip-nav"
           sx={{
             justifyContent: 'center',
             flexDirection: 'row-reverse',
@@ -73,20 +71,22 @@ function Layout({children, pageContext}) {
                 top: HEADER_HEIGHT + 48,
                 maxHeight: `calc(100vh - ${HEADER_HEIGHT}px - 48px)`
               }}
-              css={{gridArea: 'table-of-contents', overflow: 'auto'}}
+              css={{ gridArea: 'table-of-contents', overflow: 'auto' }}
             >
-              <Heading as="h3" sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
+              <Heading as="h3" sx={{ fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3 }} id="toc-heading">
                 On this page
               </Heading>
               <TableOfContents aria-labelledby="toc-heading" items={pageContext.tableOfContents.items} />
             </Box>
           ) : null}
-          <Box sx={{width: '100%', maxWidth: '960px'}}>
-            <Box sx={{mb: 4}}>
-              <Box sx={{alignItems: 'center', display: 'flex'}}>
+          <Box
+            sx={{ width: '100%', maxWidth: '960px' }}>
+            <Box as="main"
+              id="skip-nav" sx={{ mb: 4 }}>
+              <Box sx={{ alignItems: 'center', display: 'flex' }}>
                 <Heading as="h1">{title}</Heading>{' '}
               </Box>
-              {description ? <Box sx={{fontSize: 3, mb: 3}}>{description}</Box> : null}
+              {description ? <Box sx={{ fontSize: 3, mb: 3 }}>{description}</Box> : null}
               <Box
                 sx={{
                   display: 'flex',
@@ -156,14 +156,14 @@ function Layout({children, pageContext}) {
                   borderRadius: 2
                 }}
               >
-                <Box sx={{px: 3, py: 2}}>
+                <Box sx={{ px: 3, py: 2 }}>
                   <Box
-                    sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
+                    sx={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex' }}
                   >
-                    <Text sx={{fontWeight: 'bold'}}>On this page</Text>
+                    <Text sx={{ fontWeight: 'bold' }}>On this page</Text>
                   </Box>
                 </Box>
-                <Box sx={{borderTop: '1px solid', borderColor: 'border.muted'}}>
+                <Box sx={{ borderTop: '1px solid', borderColor: 'border.muted' }}>
                   <TableOfContents items={pageContext.tableOfContents.items} />
                 </Box>
               </Box>
@@ -171,7 +171,7 @@ function Layout({children, pageContext}) {
             {children}
             <PageFooter
               editUrl={pageContext.editUrl}
-              contributors={pageContext.contributors.concat(additionalContributors.map(login => ({login})))}
+              contributors={pageContext.contributors.concat(additionalContributors.map(login => ({ login })))}
             />
           </Box>
         </Box>

--- a/theme/src/components/nav-items.js
+++ b/theme/src/components/nav-items.js
@@ -31,10 +31,10 @@ function NavItem({href, children}) {
 function NavItems({items}) {
   return (
     <>
-      <VisuallyHidden>
-        <h3 id="nav-heading">Site navigation</h3>
-      </VisuallyHidden>
-      <NavList aria-labelledby="nav-heading">
+      <NavList aria-label="Site">
+        <VisuallyHidden>
+          <h3 id="nav-heading">Site navigation</h3>
+        </VisuallyHidden>
         {items.map(item => (
           <React.Fragment key={item.title}>
             {item.children ? (

--- a/theme/src/components/nav-items.js
+++ b/theme/src/components/nav-items.js
@@ -33,7 +33,7 @@ function NavItems({items}) {
     <>
       <NavList aria-label="Site">
         <VisuallyHidden>
-          <h3 id="nav-heading">Site navigation</h3>
+          <h3>Site navigation</h3>
         </VisuallyHidden>
         {items.map(item => (
           <React.Fragment key={item.title}>

--- a/theme/src/components/page-footer.js
+++ b/theme/src/components/page-footer.js
@@ -20,7 +20,7 @@ function PageFooter({editUrl, contributors}) {
       }}
     >
       <VisuallyHidden>
-        <h3 id="footer-heading">Page footer</h3>
+        <h2 id="footer-heading">Footer</h2>
       </VisuallyHidden>
       <Box sx={{gridGap: 4, display: 'grid'}}>
         {editUrl ? (

--- a/theme/src/components/wrap-page-element.js
+++ b/theme/src/components/wrap-page-element.js
@@ -1,7 +1,6 @@
 import {BaseStyles, themeGet} from '@primer/react'
 import React from 'react'
 import {createGlobalStyle} from 'styled-components'
-import SkipLink from './skip-link'
 
 const GlobalStyles = createGlobalStyle`
   body {
@@ -29,7 +28,6 @@ function wrapPageElement({element}) {
   return (
     <BaseStyles>
       <GlobalStyles />
-      <SkipLink />
       {element}
     </BaseStyles>
   )


### PR DESCRIPTION
### What
A couple of accessibility improvements:

- [x] skip to content should be in the header component
- [x] remove header `aria-labelledby` (it's not needed) 
- [x] remove heading wrapping breadcrumbs  
- [x] change the navigation h3 to an h2 
- [x] move navigation header to live inside the Navigation component
- [x] remove the `aria-abelledby` in nav because `navigation` is being read twice and it is repetitive. Instead add `aria-label=site` 
- [x] Move the footer outside of the main landmark
- [x] Change the footer h3 to h2  
- [x] Change the footer header to be footer instead of page footer 
		
		
		
@colebemis Sorry I ended up re-vising a couple of things I had you add. One small note on this pr I was not having luck getting `yarn workspace docs develop` to run so moving the navigation heading has not been tested. 