### PR TITLE
Wrap root node with `SSRProvider`

### DIFF
--- a/.changeset/six-rings-smile.md
+++ b/.changeset/six-rings-smile.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+Wrap root node with an SSRProvider

--- a/theme/src/components/wrap-root-element.js
+++ b/theme/src/components/wrap-root-element.js
@@ -1,3 +1,4 @@
+import {SSRProvider} from '@react-aria/ssr'
 import {MDXProvider} from '@mdx-js/react'
 import {ThemeProvider} from '@primer/react'
 import Link from './link'
@@ -52,9 +53,11 @@ const components = {
 
 function wrapRootElement({element}) {
   return (
-    <MDXProvider components={components}>
-      <ThemeProvider>{element}</ThemeProvider>
-    </MDXProvider>
+    <SSRProvider>
+      <MDXProvider components={components}>
+        <ThemeProvider>{element}</ThemeProvider>
+      </MDXProvider>
+    </SSRProvider>
   )
 }
 


### PR DESCRIPTION
The primer/design project sees thousands of the following warning messages logged on every deploy:

```
When server rendering, you must wrap your application in an <SSRProvider>
```

I believe they are now impacting our ability to deploy, as builds take > 1.5 hours. I've never actually seen one finish. This may be the culprit.