### PR TITLE
Update navigation

### DIFF
--- a/.changeset/stupid-singers-sort.md
+++ b/.changeset/stupid-singers-sort.md
@@ -1,0 +1,10 @@
+---
+'@primer/gatsby-theme-doctocat': minor
+---
+
+Navigation updates:
+
+- Remove monospace font
+- Remove dark background and update link colors
+- Use UnderlineNav for top right links to provide the correct styling
+- Remove "View components" and "React components" from top and leave "Brand" and "About"

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -1,5 +1,5 @@
 import {MarkGithubIcon, SearchIcon, ThreeBarsIcon} from '@primer/octicons-react'
-import {Box, Button, Link, StyledOcticon, Text, ThemeProvider, useTheme} from '@primer/react'
+import {Box, Button, Link, StyledOcticon, Text, ThemeProvider, useTheme, UnderlineNav} from '@primer/react'
 import VisuallyHidden from './visually-hidden'
 import {Link as GatsbyLink} from 'gatsby'
 import React from 'react'
@@ -7,19 +7,18 @@ import primerNavItems from '../primer-nav.yml'
 import useSiteMetadata from '../use-site-metadata'
 import MobileSearch from './mobile-search'
 import NavDrawer, {useNavDrawerState} from './nav-drawer'
-import NavDropdown, {NavDropdownItem} from './nav-dropdown'
 import Search from './search'
 import SkipLink from './skip-link'
 
 export const HEADER_HEIGHT = 66
 
-function Header({isSearchEnabled}) {
+function Header({isSearchEnabled, path}) {
   const {theme} = useTheme()
   const [isNavDrawerOpen, setIsNavDrawerOpen] = useNavDrawerState(theme.breakpoints[2])
   const [isMobileSearchOpen, setIsMobileSearchOpen] = React.useState(false)
   const siteMetadata = useSiteMetadata()
   return (
-    <ThemeProvider colorMode="night" nightScheme="dark_dimmed">
+    <ThemeProvider>
       <Box sx={{position: 'sticky', top: 0, zIndex: 1}}>
         <Box
           as="header"
@@ -94,7 +93,7 @@ function Header({isSearchEnabled}) {
           </Box>
           <Box>
             <Box sx={{display: ['none', null, null, 'block']}}>
-              <PrimerNavItems siteMetadata={siteMetadata} items={primerNavItems} />
+              <PrimerNavItems path={path} siteMetadata={siteMetadata} items={primerNavItems} />
             </Box>
             <Box sx={{display: ['flex', null, null, 'none']}}>
               {isSearchEnabled ? (
@@ -135,7 +134,7 @@ Header.defaultProps = {
   isSearchEnabled: true
 }
 
-function PrimerNavItems({siteMetadata, items}) {
+function PrimerNavItems({siteMetadata, items, path}) {
   return (
     <>
       <VisuallyHidden>
@@ -145,36 +144,12 @@ function PrimerNavItems({siteMetadata, items}) {
         as={'nav'}
         sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', color: 'fg.default', gap: 2}}
       >
+        <UnderlineNav aria-label="Main"></UnderlineNav>
         {items.map((item, index) => {
-          if (item.children) {
-            return (
-              <Box key={index}>
-                <NavDropdown title={item.title}>
-                  {item.children.map(child => (
-                    <NavDropdownItem key={child.title} href={child.url}>
-                      {child.title}
-                    </NavDropdownItem>
-                  ))}
-                </NavDropdown>
-              </Box>
-            )
-          }
-
           return (
-            <Link
-              key={index}
-              href={item.url}
-              sx={{
-                display: 'block',
-                color: 'fg.default',
-                fontSize: 2,
-                fontWeight: 'bold',
-                ml: 2,
-                mr: 2
-              }}
-            >
+            <UnderlineNav.Link key={index} href={item.url} selected={item.url === path}>
               {item.title}
-            </Link>
+            </UnderlineNav.Link>
           )
         })}
       </Box>

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -49,7 +49,6 @@ function Header({isSearchEnabled}) {
                 href={siteMetadata.header.url}
                 sx={{
                   color: 'accent.fg',
-                  fontFamily: 'mono',
                   display: [
                     // We only hide "Primer" on small viewports if a shortName is defined.
                     siteMetadata.shortName ? 'none' : 'inline-block',
@@ -69,7 +68,6 @@ function Header({isSearchEnabled}) {
                     sx={{
                       display: ['none', null, null, 'inline-block'],
                       color: 'accent.fg',
-                      fontFamily: 'mono',
                       mx: 2
                     }}
                   >
@@ -80,8 +78,7 @@ function Header({isSearchEnabled}) {
                   as={GatsbyLink}
                   to="/"
                   sx={{
-                    color: 'accent.fg',
-                    fontFamily: 'mono'
+                    color: 'accent.fg'
                   }}
                 >
                   {siteMetadata.shortName}

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -10,7 +10,7 @@ import NavDrawer, {useNavDrawerState} from './nav-drawer'
 import Search from './search'
 import SkipLink from './skip-link'
 
-export const HEADER_HEIGHT = 66
+export const HEADER_HEIGHT = 56
 
 function Header({isSearchEnabled, path}) {
   const {theme} = useTheme()
@@ -28,7 +28,9 @@ function Header({isSearchEnabled, path}) {
             px: [3, null, null, 4],
             alignItems: 'center',
             justifyContent: 'space-between',
-            bg: 'canvas.default'
+            bg: 'canvas.default',
+            border: '1px solid',
+            borderColor: 'border.muted'
           }}
         >
           <SkipLink />
@@ -41,13 +43,14 @@ function Header({isSearchEnabled, path}) {
                 lineHeight: 'condensedUltra'
               }}
             >
-              <StyledOcticon icon={MarkGithubIcon} size="medium" />
+              <StyledOcticon icon={MarkGithubIcon} size="24px" />
             </Link>
             {siteMetadata.header.title ? (
               <Link
                 href={siteMetadata.header.url}
                 sx={{
                   color: 'fg.default',
+                  fontWeight: 'bold',
                   display: [
                     // We only hide "Primer" on small viewports if a shortName is defined.
                     siteMetadata.shortName ? 'none' : 'inline-block',
@@ -77,6 +80,7 @@ function Header({isSearchEnabled, path}) {
                   as={GatsbyLink}
                   to="/"
                   sx={{
+                    fontWeight: 'bold',
                     color: 'fg.default'
                   }}
                 >
@@ -84,16 +88,15 @@ function Header({isSearchEnabled, path}) {
                 </Link>
               </>
             ) : null}
-
-            {isSearchEnabled ? (
-              <Box sx={{display: ['none', null, null, 'block'], ml: 4}}>
-                <Search />
-              </Box>
-            ) : null}
           </Box>
           <Box>
-            <Box sx={{display: ['none', null, null, 'block']}}>
+            <Box sx={{display: ['none', null, null, 'flex'], alignItems: 'center'}}>
               <PrimerNavItems path={path} siteMetadata={siteMetadata} items={primerNavItems} />
+              {isSearchEnabled ? (
+                <Box sx={{display: ['none', null, null, 'block'], ml: 3}}>
+                  <Search />
+                </Box>
+              ) : null}
             </Box>
             <Box sx={{display: ['flex', null, null, 'none']}}>
               {isSearchEnabled ? (
@@ -140,11 +143,7 @@ function PrimerNavItems({siteMetadata, items, path}) {
       <VisuallyHidden>
         <h3 aria-labelledby="site-header">{siteMetadata.header.title} </h3>
       </VisuallyHidden>
-      <Box
-        as={'nav'}
-        sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', color: 'fg.default', gap: 2}}
-      >
-        <UnderlineNav aria-label="Main"></UnderlineNav>
+      <UnderlineNav aria-label="top navigation" sx={{border: 'none'}}>
         {items.map((item, index) => {
           return (
             <UnderlineNav.Link key={index} href={item.url} selected={item.url === path}>
@@ -152,7 +151,7 @@ function PrimerNavItems({siteMetadata, items, path}) {
             </UnderlineNav.Link>
           )
         })}
-      </Box>
+      </UnderlineNav>
     </>
   )
 }

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -143,7 +143,7 @@ function PrimerNavItems({siteMetadata, items, path}) {
       <VisuallyHidden>
         <h3 aria-labelledby="site-header">{siteMetadata.header.title} </h3>
       </VisuallyHidden>
-      <UnderlineNav aria-label="top navigation" sx={{border: 'none'}}>
+      <UnderlineNav aria-label="main navigation" sx={{border: 'none'}}>
         {items.map((item, index) => {
           return (
             <UnderlineNav.Link key={index} href={item.url} selected={item.url === path}>

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -36,7 +36,7 @@ function Header({isSearchEnabled, path}) {
             <Link
               href={siteMetadata.header.logoUrl}
               sx={{
-                color: 'accent.fg',
+                color: 'fg.default',
                 mr: 3,
                 lineHeight: 'condensedUltra'
               }}
@@ -47,7 +47,7 @@ function Header({isSearchEnabled, path}) {
               <Link
                 href={siteMetadata.header.url}
                 sx={{
-                  color: 'accent.fg',
+                  color: 'fg.default',
                   display: [
                     // We only hide "Primer" on small viewports if a shortName is defined.
                     siteMetadata.shortName ? 'none' : 'inline-block',
@@ -66,7 +66,7 @@ function Header({isSearchEnabled, path}) {
                   <Text
                     sx={{
                       display: ['none', null, null, 'inline-block'],
-                      color: 'accent.fg',
+                      color: 'fg.default',
                       mx: 2
                     }}
                   >
@@ -77,7 +77,7 @@ function Header({isSearchEnabled, path}) {
                   as={GatsbyLink}
                   to="/"
                   sx={{
-                    color: 'accent.fg'
+                    color: 'fg.default'
                   }}
                 >
                   {siteMetadata.shortName}

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -72,7 +72,7 @@ function Layout({children, pageContext, path}) {
   return (
     <Box sx={{flexDirection: 'column', minHeight: '100vh', display: 'flex'}}>
       <Head title={title} description={description} />
-      <Header />
+      <Header path={path} />
       <Box css={{zIndex: 0}} sx={{flex: '1 1 auto', flexDirection: 'row', display: 'flex'}}>
         <Box sx={{display: ['none', null, null, 'block']}}>
           <Sidebar />

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -1,5 +1,3 @@
-- title: Contributing
-  url: /contributing
 - title: Brand
   url: https://primer.style/brand
 - title: About

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -1,26 +1,4 @@
-- title: Design
-  children:
-    - title: Interface guidelines
-      url: https://primer.style/design
-    - title: Octicons
-      url: https://primer.style/design/foundations/icons
-    - title: Desktop
-      url: https://primer.style/design/native/desktop
-    - title: Mobile
-      url: https://primer.style/design/native/mobile
-    - title: CLI
-      url: https://primer.style/design/native/cli
-- title: Build
-  children:
-    - title: CSS
-      url: https://primer.style/css
-    - title: React
-      url: https://primer.style/react
-    - title: React Brand
-      url: https://primer.style/brand
-    - title: ViewComponents
-      url: https://primer.style/view-components
-- title: Contribute
-  url: https://primer.style/design/guides/contribute
+- title: Brand
+  url: https://primer.style/brand
 - title: About
   url: https://primer.style/design/guides/about

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -1,3 +1,5 @@
+- title: Contributing
+  url: /contributing
 - title: Brand
   url: https://primer.style/brand
 - title: About


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/2426

👓 : https://primer-6f994bf089-26493675.drafts.github.io/

- [x] Remove monospace font (SFMono?)
- [x] Remove dark background and update link colors (this is in preparation for color mode support)
- [x] Use UnderlineNav for top right links to provide the correct styling + selected states ([example](https://www.figma.com/file/byiGhUWH17SLpeQStmULYA/Doctocat-for-Primer%3A--Q4-IA-%2B-UX-proposal?type=design&node-id=11%3A11011&mode=design&t=57gVGH8vEqnj8KZB-1))
- [x] Remove "View components" and "React components" from top
- [x] Add "Brand" link in the top navigation
- [x] Add "About us" link (if it wasn't already added from https://github.com/github/primer/issues/2425)