### PR TITLE
Base layout design updates

### DIFF
--- a/.changeset/slow-cycles-search.md
+++ b/.changeset/slow-cycles-search.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+Updates the base layout with latest designs.

--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -59,7 +59,7 @@ function MarkdownHeading({children, ...props}) {
 
 const StyledH1 = styled(StyledHeading).attrs({as: 'h1'})`
   padding-bottom: ${themeGet('space.2')};
-  font-size: ${themeGet('fontSizes.5')};
+  font-size: ${themeGet('fontSizes.7')};
   border-bottom: 1px solid ${themeGet('colors.border.default')};
 `
 
@@ -67,14 +67,17 @@ const StyledH2 = styled(StyledHeading).attrs({as: 'h2'})`
   padding-bottom: ${themeGet('space.2')};
   font-size: ${themeGet('fontSizes.4')};
   border-bottom: 1px solid ${themeGet('colors.border.default')};
+  font-weight: ${themeGet('fontWeights.semibold')};
 `
 
 const StyledH3 = styled(StyledHeading).attrs({as: 'h3'})`
   font-size: ${themeGet('fontSizes.3')};
+  font-weight: ${themeGet('fontWeights.semibold')};
 `
 
 const StyledH4 = styled(StyledHeading).attrs({as: 'h4'})`
   font-size: ${themeGet('fontSizes.2')};
+  font-weight: ${themeGet('fontWeights.semibold')};
 `
 
 const StyledH5 = styled(StyledHeading).attrs({as: 'h5'})`

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -91,7 +91,7 @@ function Layout({children, pageContext, path}) {
               sx={{
                 width: 220,
                 flex: '0 0 auto',
-                marginLeft: 6,
+                marginLeft: [null, 7, 8, 9],
                 display: ['none', null, 'block'],
                 position: 'sticky',
                 top: HEADER_HEIGHT + 48,
@@ -99,7 +99,7 @@ function Layout({children, pageContext, path}) {
               }}
               css={{gridArea: 'table-of-contents', overflow: 'auto'}}
             >
-              <Heading as="h3" sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
+              <Heading as="h3" sx={{fontSize: 1, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
                 On this page
               </Heading>
               <TableOfContents aria-labelledby="toc-heading" items={pageContext.tableOfContents.items} />
@@ -117,7 +117,9 @@ function Layout({children, pageContext, path}) {
                   : null}
               </Breadcrumbs>
               <Box sx={{alignItems: 'center', display: 'flex'}}>
-                <Heading as="h1">{title}</Heading>{' '}
+                <Heading as="h1" sx={{fontSize: 7}}>
+                  {title}
+                </Heading>
               </Box>
               {description ? <Box sx={{fontSize: 3, mb: 3}}>{description}</Box> : null}
               <Box


### PR DESCRIPTION
Relates to https://github.com/github/primer/issues/2427

Note: we decided not to change the table of contents link color to blue

Before:
![Screenshot 2023-07-18 at 11 33 57 AM](https://github.com/primer/doctocat/assets/2313998/ad3ef98e-a419-4785-87f8-5d3e2d332bd4)

After:
![Screenshot 2023-07-18 at 11 33 34 AM](https://github.com/primer/doctocat/assets/2313998/142ab846-d14c-4698-b0c7-847b3022fb66)
