### PR TITLE
Remove bold weight from top header links

### DIFF
--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -171,7 +171,6 @@ function PrimerNavItems({siteMetadata, items}) {
                 display: 'block',
                 color: 'fg.default',
                 fontSize: 2,
-                fontWeight: 'bold',
                 ml: 2,
                 mr: 2
               }}


### PR DESCRIPTION
Looks like fontWeight: bold was added to the nav links, which is appearing on primer.style/design 
<img width="1691" alt="top navigation on primer.style, displaying the links in bold" src="https://github.com/primer/doctocat/assets/586552/aced27a3-005c-4d97-baaf-1c7ac76bc6fd">


Removing to revert back to original styles