### PR TITLE
Spacing and navigation fixes

### DIFF
--- a/.changeset/cool-balloons-begin.md
+++ b/.changeset/cool-balloons-begin.md
@@ -1,0 +1,7 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+- Move the heading out of the sidebar Navigation. This fixes the extra divider on top of the navigation.
+- Remove extra space below the heading when there's no status or external links
+- Remove extra space when there's no Breadcrumbs

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -107,15 +107,15 @@ function Layout({children, pageContext, path}) {
           ) : null}
           <Box sx={{width: '100%', maxWidth: '960px'}}>
             <Box as="main" id="skip-nav" sx={{mb: 4}}>
-              <Breadcrumbs sx={{mb: 4}}>
-                {breadcrumbData.length > 1
-                  ? breadcrumbData.map(item => (
-                      <Breadcrumbs.Item key={item.url} href={item.url} selected={path === item.url}>
-                        {item.title}
-                      </Breadcrumbs.Item>
-                    ))
-                  : null}
-              </Breadcrumbs>
+              {breadcrumbData.length > 1 ? (
+                <Breadcrumbs sx={{mb: 4}}>
+                  {breadcrumbData.map(item => (
+                    <Breadcrumbs.Item key={item.url} href={item.url} selected={path === item.url}>
+                      {item.title}
+                    </Breadcrumbs.Item>
+                  ))}
+                </Breadcrumbs>
+              ) : null}
               <Box sx={{alignItems: 'center', display: 'flex'}}>
                 <Heading as="h1" sx={{fontSize: 7}}>
                   {title}

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -116,68 +116,68 @@ function Layout({children, pageContext, path}) {
                   ))}
                 </Breadcrumbs>
               ) : null}
-              <Box sx={{alignItems: 'center', display: 'flex'}}>
-                <Heading as="h1" sx={{fontSize: 7}}>
-                  {title}
-                </Heading>
-              </Box>
+              <Heading as="h1" sx={{fontSize: 7}}>
+                {title}
+              </Heading>
               {description ? <Box sx={{fontSize: 3, mb: 3}}>{description}</Box> : null}
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexWrap: 'wrap',
-                  columnGap: 3,
-                  mb: 7,
-                  mt: 2,
-                  rowGap: 3,
-                  alignItems: 'center',
-                  fontSize: 1
-                }}
-              >
-                {status ? (
-                  <Box
-                    as={'ul'}
-                    sx={{
-                      display: 'flex',
-                      gap: 1,
-                      alignItems: 'center',
-                      m: 0,
-                      p: 0,
-                      paddingInline: 0,
-                      listStyle: 'none'
-                    }}
-                  >
-                    <li>
-                      <StatusLabel status={status} />
-                    </li>
-                    <li>
-                      <AccessibilityLabel a11yReviewed={a11yReviewed} />
-                    </li>
-                  </Box>
-                ) : null}
-                {source || storybook || lookbook || figma || rails || react ? (
-                  <Box
-                    as={'ul'}
-                    sx={{
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      gap: 4,
-                      alignItems: 'center',
-                      m: 0,
-                      p: 0,
-                      paddingInline: 0,
-                      listStyle: 'none'
-                    }}
-                  >
-                    {source ? <SourceLink href={source} /> : null}
-                    {lookbook ? <LookbookLink href={lookbook} /> : null}
-                    {storybook ? <StorybookLink href={storybook} /> : null}
-                    {react ? <ReactLink href={react} /> : null}
-                    {rails ? <RailsLink href={rails} /> : null}
-                    {figma ? <FigmaLink href={figma} /> : null}
-                  </Box>
-                ) : null}
-              </Box>
+              {status || source || storybook || lookbook || figma || rails || react ? (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    columnGap: 3,
+                    mb: 7,
+                    mt: 2,
+                    rowGap: 3,
+                    alignItems: 'center',
+                    fontSize: 1
+                  }}
+                >
+                  {status ? (
+                    <Box
+                      as={'ul'}
+                      sx={{
+                        display: 'flex',
+                        gap: 1,
+                        alignItems: 'center',
+                        m: 0,
+                        p: 0,
+                        paddingInline: 0,
+                        listStyle: 'none'
+                      }}
+                    >
+                      <li>
+                        <StatusLabel status={status} />
+                      </li>
+                      <li>
+                        <AccessibilityLabel a11yReviewed={a11yReviewed} />
+                      </li>
+                    </Box>
+                  ) : null}
+                  {source || storybook || lookbook || figma || rails || react ? (
+                    <Box
+                      as={'ul'}
+                      sx={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 4,
+                        alignItems: 'center',
+                        m: 0,
+                        p: 0,
+                        paddingInline: 0,
+                        listStyle: 'none'
+                      }}
+                    >
+                      {source ? <SourceLink href={source} /> : null}
+                      {lookbook ? <LookbookLink href={lookbook} /> : null}
+                      {storybook ? <StorybookLink href={storybook} /> : null}
+                      {react ? <ReactLink href={react} /> : null}
+                      {rails ? <RailsLink href={rails} /> : null}
+                      {figma ? <FigmaLink href={figma} /> : null}
+                    </Box>
+                  ) : null}
+                </Box>
+              ) : null}
             </Box>
             {pageContext.tableOfContents.items ? (
               <Box

--- a/theme/src/components/nav-items.js
+++ b/theme/src/components/nav-items.js
@@ -31,10 +31,10 @@ function NavItem({href, children}) {
 function NavItems({items}) {
   return (
     <>
+      <VisuallyHidden>
+        <h3>Site navigation</h3>
+      </VisuallyHidden>
       <NavList aria-label="Site">
-        <VisuallyHidden>
-          <h3>Site navigation</h3>
-        </VisuallyHidden>
         {items.map(item => (
           <React.Fragment key={item.title}>
             {item.children ? (


### PR DESCRIPTION
Fixes minor visual issues

- Aligned with @kendallgassner we could safely move the heading out of the sidebar Navigation. This fixes the extra divider on top of the navigation.

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img  alt="Screenshot 2023-07-20 at 18 26 02" src="https://github.com/primer/doctocat/assets/912236/87ba21fc-8efb-4e7e-b475-df76d2f09a5f">
 </td>
<td valign="top">
<img  alt="Screenshot 2023-07-20 at 18 25 53" src="https://github.com/primer/doctocat/assets/912236/c502b42f-234f-40a7-820c-e88632437a4b">
</td>
</tr>
</table>



- Remove extra space below the heading when there's no status or external links
<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="1096" alt="Screenshot 2023-07-20 at 18 03 15" src="https://github.com/primer/doctocat/assets/912236/7874d1e2-c55e-4b76-b683-dddb9a416e45">
 </td>
<td valign="top">
<img width="1099" alt="Screenshot 2023-07-20 at 18 30 36" src="https://github.com/primer/doctocat/assets/912236/a85b5a70-2a07-4c85-9140-69d0e62ec76d">


</td>
</tr>
</table>


- Remove extra space when there's no `Breadcrumbs`

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="1072" alt="Screenshot 2023-07-20 at 17 53 53" src="https://github.com/primer/doctocat/assets/912236/dbe83192-e6f9-4b2f-9a60-29dee7be4297">
 </td>
<td valign="top">
<img width="1099" alt="Screenshot 2023-07-20 at 18 30 36" src="https://github.com/primer/doctocat/assets/912236/a85b5a70-2a07-4c85-9140-69d0e62ec76d">

</td>
</tr>
</table>


