### PR TITLE
About us link and style fixes

### DIFF
--- a/.changeset/forty-paws-yawn.md
+++ b/.changeset/forty-paws-yawn.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': patch
+---
+
+Fix the primer navigation about link

--- a/.changeset/forty-paws-yawn.md
+++ b/.changeset/forty-paws-yawn.md
@@ -2,4 +2,5 @@
 '@primer/gatsby-theme-doctocat': patch
 ---
 
-Fix the primer navigation about link
+- Fix the primer navigation about link
+- Removes mono space font in the nav drawer + fontweight bold to match top left navigation

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -52,7 +52,6 @@ function Header({isSearchEnabled, path}) {
                 sx={{
                   color: 'fg.default',
                   fontWeight: 'bold',
-                  fontSize: 1,
                   display: [
                     // We only hide "Primer" on small viewports if a shortName is defined.
                     siteMetadata.shortName ? 'none' : 'inline-block',
@@ -72,7 +71,6 @@ function Header({isSearchEnabled, path}) {
                     sx={{
                       display: ['none', null, null, 'inline-block'],
                       color: 'fg.default',
-                      fontSize: 1,
                       mx: 2
                     }}
                   >
@@ -84,7 +82,6 @@ function Header({isSearchEnabled, path}) {
                   to="/"
                   sx={{
                     fontWeight: 'bold',
-                    fontSize: 1,
                     color: 'fg.default'
                   }}
                 >
@@ -150,7 +147,12 @@ function PrimerNavItems({siteMetadata, items, path}) {
       <UnderlineNav aria-label="main navigation" sx={{border: 'none'}}>
         {items.map((item, index) => {
           return (
-            <UnderlineNav.Link key={index} href={item.url} selected={item.url === siteMetadata.header.url + path}>
+            <UnderlineNav.Link
+              key={index}
+              href={item.url}
+              selected={item.url === siteMetadata.header.url + path}
+              sx={{fontSize: 2, lineHeight: 'condensed'}}
+            >
               {item.title}
             </UnderlineNav.Link>
           )

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -52,6 +52,7 @@ function Header({isSearchEnabled, path}) {
                 sx={{
                   color: 'fg.default',
                   fontWeight: 'bold',
+                  fontSize: 1,
                   display: [
                     // We only hide "Primer" on small viewports if a shortName is defined.
                     siteMetadata.shortName ? 'none' : 'inline-block',
@@ -71,6 +72,7 @@ function Header({isSearchEnabled, path}) {
                     sx={{
                       display: ['none', null, null, 'inline-block'],
                       color: 'fg.default',
+                      fontSize: 1,
                       mx: 2
                     }}
                   >
@@ -82,6 +84,7 @@ function Header({isSearchEnabled, path}) {
                   to="/"
                   sx={{
                     fontWeight: 'bold',
+                    fontSize: 1,
                     color: 'fg.default'
                   }}
                 >

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -60,7 +60,7 @@ function NavDrawer({isOpen, onDismiss}) {
             }}
           >
             <Box sx={{py: 3, pl: 4, pr: 3, alignItems: 'center', justifyContent: 'space-between', display: 'flex'}}>
-              <Link href="https://primer.style" sx={{fontFamily: 'mono', color: 'inherit'}}>
+              <Link href="https://primer.style" sx={{fontWeight: 'bold', color: 'inherit'}}>
                 Primer
               </Link>
               <Button aria-label="Close" onClick={onDismiss}>
@@ -86,7 +86,7 @@ function NavDrawer({isOpen, onDismiss}) {
               <Link
                 as={GatsbyLink}
                 to="/"
-                sx={{display: 'inline-block', color: 'inherit', fontFamily: 'mono', mx: 4, mt: 4}}
+                sx={{display: 'inline-block', color: 'inherit', fontWeight: 'bold', mx: 4, mt: 4}}
               >
                 {siteMetadata.title}
               </Link>
@@ -111,7 +111,8 @@ function PrimerNavItems({items}) {
           borderRadius: 0,
           borderTopWidth: index !== 0 ? 1 : 0,
           borderColor: 'border.muted',
-          p: 4,
+          px: 4,
+          py: 3,
           borderStyle: 'solid'
         }}
       >

--- a/theme/src/components/text-input.js
+++ b/theme/src/components/text-input.js
@@ -7,7 +7,7 @@ const TextInput = styled(PrimerTextInput)`
    * TODO: Update font-size of TextInput in @primer/react.
    */
   input {
-    // font-size: ${themeGet('fontSizes.2')} !important;
+    font-size: ${themeGet('fontSizes.2')} !important;
   }
 
   input::placeholder {

--- a/theme/src/components/text-input.js
+++ b/theme/src/components/text-input.js
@@ -7,7 +7,7 @@ const TextInput = styled(PrimerTextInput)`
    * TODO: Update font-size of TextInput in @primer/react.
    */
   input {
-    font-size: ${themeGet('fontSizes.2')} !important;
+    // font-size: ${themeGet('fontSizes.2')} !important;
   }
 
   input::placeholder {

--- a/theme/src/primer-nav.yml
+++ b/theme/src/primer-nav.yml
@@ -1,4 +1,4 @@
 - title: Brand
   url: https://primer.style/brand
 - title: About
-  url: https://primer.style/design/guides/about
+  url: https://primer.style/design/about


### PR DESCRIPTION
- [x] Fixes the about link in primer nav
- [x] Removes mono space font in the nav drawer + fontweight bold to match top left navigation
- [x] Uses 16px in the top navigation

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="517" alt="Screenshot 2023-07-24 at 08 49 34" src="https://github.com/primer/doctocat/assets/912236/def1822e-e854-43b9-8c05-7126d6dbfe68">

 </td>
<td valign="top">
<img width="518" alt="Screenshot 2023-07-24 at 08 49 18" src="https://github.com/primer/doctocat/assets/912236/dfe47ff7-e51a-465f-8f84-7d5b9809535c">

</td>
</tr>
</table>

