### PR TITLE
Ability to add custom docs to search

### DIFF
--- a/.changeset/fresh-files-melt.md
+++ b/.changeset/fresh-files-melt.md
@@ -1,0 +1,5 @@
+---
+'@primer/gatsby-theme-doctocat': minor
+---
+
+Ability to add custom docs to search

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -9,6 +9,17 @@ const mdx = require(`gatsby-plugin-mdx/utils/mdx`)
 
 const CONTRIBUTOR_CACHE = new Map()
 
+exports.createSchemaCustomization = async ({actions}) => {
+  const typeDefs = `
+    type CustomSearchDoc implements Node {
+      path: String!
+      title: String!
+      rawBody: String!
+    }
+  `
+  actions.createTypes(typeDefs)
+}
+
 exports.createPages = async ({graphql, actions}, themeOptions) => {
   const repo = getPkgRepo(readPkgUp.sync().package)
 

--- a/theme/src/use-search.js
+++ b/theme/src/use-search.js
@@ -10,7 +10,7 @@ function useSearch(query) {
   const workerRef = React.useRef()
 
   const data = useStaticQuery(graphql`
-    {
+    query {
       allMdx {
         nodes {
           fileAbsolutePath
@@ -28,15 +28,17 @@ function useSearch(query) {
       }
 
       allCustomSearchDoc {
-        path
-        title
-        rawBody
+        nodes {
+          path
+          title
+          rawBody
+        }
       }
     }
   `)
 
   const list = React.useMemo(() => {
-    const mdxData = data.allMdx.nodes.map(node => ({
+    const results = data.allMdx.nodes.map(node => ({
       path: ensureAbsolute(
         path.join(node.parent.relativeDirectory, node.parent.name === 'index' ? '/' : node.parent.name)
       ),
@@ -44,7 +46,11 @@ function useSearch(query) {
       rawBody: node.rawBody
     }))
 
-    return [...mdxData, ...data.allCustomSearchDoc.nodes]
+    if (data.allCustomSearchDoc.nodes) {
+      results.push(...data.allCustomSearchDoc.nodes)
+    }
+
+    return results
   }, [data])
 
   const [results, setResults] = React.useState(list)

--- a/theme/src/use-search.js
+++ b/theme/src/use-search.js
@@ -26,20 +26,26 @@ function useSearch(query) {
           }
         }
       }
+
+      allCustomSearchDoc {
+        path
+        title
+        rawBody
+      }
     }
   `)
 
-  const list = React.useMemo(
-    () =>
-      data.allMdx.nodes.map(node => ({
-        path: ensureAbsolute(
-          path.join(node.parent.relativeDirectory, node.parent.name === 'index' ? '/' : node.parent.name)
-        ),
-        title: node.frontmatter.title,
-        rawBody: node.rawBody
-      })),
-    [data]
-  )
+  const list = React.useMemo(() => {
+    const mdxData = data.allMdx.nodes.map(node => ({
+      path: ensureAbsolute(
+        path.join(node.parent.relativeDirectory, node.parent.name === 'index' ? '/' : node.parent.name)
+      ),
+      title: node.frontmatter.title,
+      rawBody: node.rawBody
+    }))
+
+    return [...mdxData, data.allCustomSearchDoc.nodes]
+  }, [data])
 
   const [results, setResults] = React.useState(list)
 

--- a/theme/src/use-search.js
+++ b/theme/src/use-search.js
@@ -44,7 +44,7 @@ function useSearch(query) {
       rawBody: node.rawBody
     }))
 
-    return [...mdxData, data.allCustomSearchDoc.nodes]
+    return [...mdxData, ...data.allCustomSearchDoc.nodes]
   }, [data])
 
   const [results, setResults] = React.useState(list)


### PR DESCRIPTION
This PR allows adding custom documents (text) to the search mechanism. The use-case is adding Dotcom shared components to search on primer.style, which don't actually have their own pages.