### PR TITLE
Breadcrumbs fix

### DIFF
--- a/.changeset/moody-carrots-know.md
+++ b/.changeset/moody-carrots-know.md
@@ -1,0 +1,5 @@
+---
+"@primer/gatsby-theme-doctocat": patch
+---
+
+- Add withPrefix to breadcrumbs

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -15,6 +15,7 @@ import StorybookLink from './storybook-link'
 import FigmaLink from './figma-link'
 import TableOfContents from './table-of-contents'
 import navItems from '../nav.yml'
+import withPrefix from 'gatsby'
 
 const getPageAncestry = (url, object) => {
   const result = []
@@ -110,7 +111,7 @@ function Layout({children, pageContext, path}) {
               {breadcrumbData.length > 1 ? (
                 <Breadcrumbs sx={{mb: 4}}>
                   {breadcrumbData.map(item => (
-                    <Breadcrumbs.Item key={item.url} href={item.url} selected={path === item.url}>
+                    <Breadcrumbs.Item key={item.url} href={withPrefix(item.url)} selected={path === item.url}>
                       {item.title}
                     </Breadcrumbs.Item>
                   ))}

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -15,7 +15,7 @@ import StorybookLink from './storybook-link'
 import FigmaLink from './figma-link'
 import TableOfContents from './table-of-contents'
 import navItems from '../nav.yml'
-import withPrefix from 'gatsby'
+import {withPrefix} from 'gatsby'
 
 const getPageAncestry = (url, object) => {
   const result = []


### PR DESCRIPTION
Breadcrumbs links are broken right now on primer.style/design. Testing a fix over in /design/ https://github.com/primer/design/pull/566

Current:
Clicking on the breadcrumb links will 404, the URL is missing `/design/` (see example by clicking on CLI in the breadcrumb https://primer.style/design/native/cli/getting-started)

Expected:
The breadcrumb URL should direct to primer.style/design/`path` , not primer.style/`path`