### PR TITLE
chore: add yarn classic version to project

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   "dependencies": {
     "@changesets/changelog-github": "^0.2.7",
     "@changesets/cli": "^2.10.3"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
When using `yarn` along with `doctocat`, it is expected that yarn classic (v1) is used. However, if someone is using a newer version of `yarn` then they will not be able to install/run commands as-intended.

This change uses the `yarn set version classic` command to make sure yarn v1 is installed and will be used by all versions of yarn so that things are consistent within the project.