### PR TITLE
Update paragraph.js

### DIFF
--- a/theme/src/components/paragraph.js
+++ b/theme/src/components/paragraph.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import themeGet from '@styled-system/theme-get'
 
 const Paragraph = styled.p`
-  margin: 0 0 ${themeGet('space.3')};
+  margin: 0 0 ${themeGet('space.4')};
 `
 
 export default Paragraph


### PR DESCRIPTION
Increase the margin bottom of paragraphs from 16px (space.3) to 24px (space.4) 

View context in the Issue here: https://github.com/primer/doctocat/issues/699