### PR TITLE
Update heading.js

### DIFF
--- a/theme/src/components/heading.js
+++ b/theme/src/components/heading.js
@@ -8,8 +8,8 @@ import styled from 'styled-components'
 import {HEADER_HEIGHT} from './header'
 
 const StyledHeading = styled(Heading)`
-  margin-top: ${themeGet('space.4')};
-  margin-bottom: ${themeGet('space.3')};
+  margin-top: ${themeGet('space.8')};
+  margin-bottom: ${themeGet('space.4')};
   scroll-margin-top: ${HEADER_HEIGHT + 24}px;
   line-height: ${themeGet('lineHeights.condensed')};
 
@@ -58,13 +58,13 @@ function MarkdownHeading({children, ...props}) {
 }
 
 const StyledH1 = styled(StyledHeading).attrs({as: 'h1'})`
-  padding-bottom: ${themeGet('space.2')};
+  padding-bottom: ${themeGet('space.3')};
   font-size: ${themeGet('fontSizes.7')};
   border-bottom: 1px solid ${themeGet('colors.border.default')};
 `
 
 const StyledH2 = styled(StyledHeading).attrs({as: 'h2'})`
-  padding-bottom: ${themeGet('space.2')};
+  padding-bottom: ${themeGet('space.3')};
   font-size: ${themeGet('fontSizes.4')};
   border-bottom: 1px solid ${themeGet('colors.border.default')};
   font-weight: ${themeGet('fontWeights.semibold')};


### PR DESCRIPTION
Increase margin and padding of headings for a improved reading experience

See issue here: https://github.com/primer/doctocat/issues/699

Changes:
- Margin top all heading to 1margin-top: 64px1 (previously 24px)
- Margin bottom of all heading increase by one step 16 -> 24
- Padding bottom of h1 and h2  adjusted to match margin bottom increase by one step 16 -> 24px

------
Previews:

H1 - H2
<img width="1820" alt="Screenshot 2023-11-29 at 12 14 22 PM" src="https://github.com/primer/doctocat/assets/10632534/099243b3-2414-4b0c-9cdd-fe650a4c460c">

H3 - H4
<img width="1820" alt="Screenshot 2023-11-29 at 12 14 56 PM" src="https://github.com/primer/doctocat/assets/10632534/8e83fe61-9499-44d4-9086-be5f560ab019">


