### PR TITLE
Fix CI issues 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,13 +2399,11 @@
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
@@ -5174,11 +5172,6 @@
     "node_modules/@types/styled-system__theme-get": {
       "version": "5.0.1",
       "license": "MIT"
-    },
-    "node_modules/@types/stylis": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.3.tgz",
-      "integrity": "sha512-86XLCVEmWagiUEbr2AjSbeY4qHN9jMm3pgM3PuBYfLIbT0MpDSnA3GA/4W7KoH/C/eeK77kNaeIxZzjhKYIBgw=="
     },
     "node_modules/@types/tmp": {
       "version": "0.0.33",
@@ -15112,7 +15105,6 @@
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -24976,10 +24968,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.5",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -25008,20 +24999,17 @@
     "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.0"
       }
     },
     "node_modules/styled-components/node_modules/@emotion/memoize": {
       "version": "0.8.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/styled-components/node_modules/supports-color": {
       "version": "5.5.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -25072,11 +25060,6 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/subscriptions-transport-ws": {
       "version": "0.9.19",
@@ -27677,7 +27660,7 @@
         "react-measure": "^2.3.0",
         "read-pkg-up": "^6.0.0",
         "sentence-case": "^2.1.1",
-        "styled-components": "^6.1.0",
+        "styled-components": "^5.3.11",
         "styled-system": "^5.0.18",
         "worker-loader": "^3.0.2"
       },
@@ -27701,24 +27684,6 @@
         "react": "^18.x",
         "react-dom": "^18.x"
       }
-    },
-    "theme/node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.1"
-      }
-    },
-    "theme/node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
-    },
-    "theme/node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
     },
     "theme/node_modules/@eslint/eslintrc": {
       "version": "2.1.2",
@@ -28402,38 +28367,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "theme/node_modules/styled-components": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.0.tgz",
-      "integrity": "sha512-VWNfYYBuXzuLS/QYEeoPgMErP26WL+dX9//rEh80B2mmlS1yRxRxuL5eax4m6ybYEUoHWlTy2XOU32767mlMkg==",
-      "dependencies": {
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@emotion/unitless": "^0.8.0",
-        "@types/stylis": "^4.0.2",
-        "css-to-react-native": "^3.2.0",
-        "csstype": "^3.1.2",
-        "postcss": "^8.4.31",
-        "shallowequal": "^1.1.0",
-        "stylis": "^4.3.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
-      }
-    },
-    "theme/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "theme/node_modules/type-fest": {
       "version": "0.20.2",

--- a/theme/package.json
+++ b/theme/package.json
@@ -84,7 +84,7 @@
     "react-measure": "^2.3.0",
     "read-pkg-up": "^6.0.0",
     "sentence-case": "^2.1.1",
-    "styled-components": "^6.1.0",
+    "styled-components": "^5.3.11",
     "styled-system": "^5.0.18",
     "worker-loader": "^3.0.2"
   }

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -149,14 +149,14 @@ function PrimerNavItems({siteMetadata, items, path, pathPrefix}) {
       <UnderlineNav aria-label="Main navigation" sx={{border: 'none'}}>
         {items.map((item, index) => {
           return (
-            <UnderlineNav.Link
+            <UnderlineNav.Item
               key={index}
               href={item.url}
               selected={item.url === siteMetadata.header.url + (pathPrefix || '') + (path || '')}
               sx={{fontSize: 2, lineHeight: 'condensed'}}
             >
               {item.title}
-            </UnderlineNav.Link>
+            </UnderlineNav.Item>
           )
         })}
       </UnderlineNav>

--- a/theme/src/components/list.js
+++ b/theme/src/components/list.js
@@ -23,7 +23,7 @@ const List = styled.ul`
   }
 `
 
-export const UL = ListBase
-export const OL = styled(ListBase).attrs({as: 'ol'})
+export const UL = List
+export const OL = styled(List).attrs({as: 'ol'})
 
 export default List

--- a/theme/src/components/list.js
+++ b/theme/src/components/list.js
@@ -24,6 +24,6 @@ const List = styled.ul`
 `
 
 export const UL = ListBase
-export const OL = styled(ListBase).attrs({ as: 'ol' })
+export const OL = styled(ListBase).attrs({as: 'ol'})
 
 export default List

--- a/theme/src/components/list.js
+++ b/theme/src/components/list.js
@@ -23,4 +23,7 @@ const List = styled.ul`
   }
 `
 
+export const UL = ListBase
+export const OL = styled(ListBase).attrs({ as: 'ol' })
+
 export default List

--- a/theme/src/components/list.js
+++ b/theme/src/components/list.js
@@ -24,6 +24,6 @@ const List = styled.ul`
 `
 
 export const UL = List
-export const OL = styled(List).attrs({as: 'ol'})
+export const OL = styled(List).attrs({as: 'ol'})``
 
 export default List

--- a/theme/src/components/live-code.js
+++ b/theme/src/components/live-code.js
@@ -106,15 +106,15 @@ function LiveCode({code, language, highlight, noinline, metastring}) {
               onChange={handleChange}
               theme={githubTheme}
               ignoreTabKey={true}
-              padding={theme.space[3]}
+              padding={theme?.space[3]}
               style={{
-                fontFamily: theme.fonts.mono,
+                fontFamily: theme?.fonts.mono,
                 fontSize: '85%',
-                borderBottomLeftRadius: theme.radii[2],
-                borderBottomRightRadius: theme.radii[2],
+                borderBottomLeftRadius: theme?.radii[2],
+                borderBottomRightRadius: theme?.radii[2],
                 border: '1px solid',
                 borderTop: 0,
-                borderColor: theme.colors.border.default,
+                borderColor: theme?.colors.border.default,
               }}
             />
           </LineHighlighter>

--- a/theme/src/components/live-code.js
+++ b/theme/src/components/live-code.js
@@ -106,15 +106,15 @@ function LiveCode({code, language, highlight, noinline, metastring}) {
               onChange={handleChange}
               theme={githubTheme}
               ignoreTabKey={true}
-              padding={theme?.space[3]}
+              padding={theme.space[3]}
               style={{
-                fontFamily: theme?.fonts.mono,
+                fontFamily: theme.fonts.mono,
                 fontSize: '85%',
-                borderBottomLeftRadius: theme?.radii[2],
-                borderBottomRightRadius: theme?.radii[2],
+                borderBottomLeftRadius: theme.radii[2],
+                borderBottomRightRadius: theme.radii[2],
                 border: '1px solid',
                 borderTop: 0,
-                borderColor: theme?.colors.border.default,
+                borderColor: theme.colors.border.default,
               }}
             />
           </LineHighlighter>

--- a/theme/src/components/wrap-root-element.js
+++ b/theme/src/components/wrap-root-element.js
@@ -14,7 +14,7 @@ import HorizontalRule from './horizontal-rule'
 import Image from './image'
 import ImageContainer from './image-container'
 import InlineCode from './inline-code'
-import List from './list'
+import {OL, UL} from './list'
 import Note from './note'
 import Paragraph from './paragraph'
 import Superscript from './superscript'
@@ -37,8 +37,8 @@ const components = {
   h4: H4,
   h5: H5,
   h6: H6,
-  ul: List,
-  ol: List.withComponent('ol'),
+  ul: UL,
+  ol: OL,
   dl: DescriptionList,
 
   // Custom components


### PR DESCRIPTION
### Motivation

Trying to fix the CI issues we're seeing.

* I fixed the Primer React upgrade issue (`<UnderlineNav.Link>` becomes `<UnderlineNav.Item>`).
* I fixed the `styled-components` upgrade issues

However, this revealed an issue with themes. I suspect this is because the `ThemeProvider` is coming from `@primer/react` and build against `styled-components@5` so it's not playing nicely with `styled-components@6`

For now, I've rolled back the `styled-components` version upgrade. We can try this again when it's updated in the dependencies.