### PR TITLE
Remove `jsx-a11y` disables

### DIFF
--- a/theme/src/components/drawer.js
+++ b/theme/src/components/drawer.js
@@ -7,14 +7,7 @@ function Drawer({isOpen, onDismiss, children}) {
   return (
     <AnimatePresence>
       {isOpen ? (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-        <div
-          // These event handlers fix a bug that caused links below the fold
-          // to be unclickable in macOS Safari.
-          // Reference: https://github.com/theKashey/react-focus-lock/issues/79
-          onMouseDown={event => event.preventDefault()}
-          onClick={event => event.target.focus()}
-        >
+        <div>
           <FocusOn returnFocus={true} onEscapeKey={() => onDismiss()}>
             <Box
               key="overlay"

--- a/theme/src/components/nav-drawer.js
+++ b/theme/src/components/nav-drawer.js
@@ -120,14 +120,7 @@ function PrimerNavItems({items}) {
           <Details key={index}>
             {({open, toggle}) => (
               <>
-                {/*eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-                <summary
-                  //The following line of code has only an onClick event and no keyboard event and its a non static
-                  //element. This is because we don't want it to be a tabstop thats tedious for keyboard users and sr's.
-                  //This needs to be a hard exception
-                  onClick={toggle}
-                  style={{cursor: 'pointer'}}
-                >
+                <summary style={{cursor: 'pointer'}}>
                   <Box sx={{alignItems: 'center', justifyContent: 'space-between', display: 'flex'}}>
                     <Text>{item.title}</Text>
                     {open ? <ChevronUpIcon /> : <ChevronDownIcon />}


### PR DESCRIPTION
Context https://github.com/github/primer/issues/3726

It appears that we no longer need to disable the offending code, as the code itself either is no longer used, or the bug that caused us to disable it has been fixed.